### PR TITLE
Added stop_on_assert command line option.

### DIFF
--- a/CppCoverage/CodeCoverageRunner.cpp
+++ b/CppCoverage/CodeCoverageRunner.cpp
@@ -64,7 +64,7 @@ namespace CppCoverage
 	CoverageData CodeCoverageRunner::RunCoverage(
 		const RunCoverageSettings& settings)
 	{
-		Debugger debugger{ settings.GetCoverChildren(), settings.GetContinueAfterCppException()};
+		Debugger debugger{ settings.GetCoverChildren(), settings.GetContinueAfterCppException(), settings.GetStopOnAssert()};
 
 		coverageFilterManager_ = std::make_shared<CoverageFilterManager>(
 			settings.GetCoverageFilterSettings(),

--- a/CppCoverage/Debugger.cpp
+++ b/CppCoverage/Debugger.cpp
@@ -59,9 +59,11 @@ namespace CppCoverage
 	//-------------------------------------------------------------------------
 	Debugger::Debugger(
 		bool coverChildren,
-		bool continueAfterCppException)
+		bool continueAfterCppException,
+        bool stopOnAssert)
 		: coverChildren_{ coverChildren }
 		, continueAfterCppException_{ continueAfterCppException }
+        , stopOnAssert_{ stopOnAssert }
 	{
 	}
 
@@ -184,7 +186,15 @@ namespace CppCoverage
 				LOG_WARNING << "It seems there is an assertion failure or you call DebugBreak() in your program.";
 				LOG_WARNING << Tools::GetSeparatorLine();
 
-				return ProcessStatus( EXCEPTION_BREAKPOINT, DBG_CONTINUE );
+                if (stopOnAssert_)
+                {
+                  LOG_WARNING << "Stop on assertion.";
+                  return ProcessStatus{ boost::none, DBG_EXCEPTION_NOT_HANDLED };
+                }
+                else
+                {
+                  return ProcessStatus(EXCEPTION_BREAKPOINT, DBG_CONTINUE);
+                }
 			}
 			case IDebugEventsHandler::ExceptionType::NotHandled:
 			{

--- a/CppCoverage/Debugger.hpp
+++ b/CppCoverage/Debugger.hpp
@@ -33,7 +33,8 @@ namespace CppCoverage
 	public:
 		Debugger(
 			bool coverChildren,
-			bool continueAfterCppException);
+			bool continueAfterCppException,
+            bool stopOnAssert);
 
 		int Debug(const StartInfo&, IDebugEventsHandler&);
 		size_t GetRunningProcesses() const;
@@ -81,7 +82,8 @@ namespace CppCoverage
 		boost::optional<DWORD> rootProcessId_;
 		bool coverChildren_;
 		bool continueAfterCppException_;
-	};
+        bool stopOnAssert_;
+    };
 }
 
 

--- a/CppCoverage/Options.cpp
+++ b/CppCoverage/Options.cpp
@@ -129,13 +129,25 @@ namespace CppCoverage
 		isContinueAfterCppExceptionModeEnabled_ = true;
 	}
 	
-	//-------------------------------------------------------------------------
+    //-------------------------------------------------------------------------
 	bool Options::IsContinueAfterCppExceptionModeEnabled() const
 	{
 		return isContinueAfterCppExceptionModeEnabled_;
 	}
 
-	//-------------------------------------------------------------------------
+    //-------------------------------------------------------------------------
+    void Options::EnableStopOnAssertMode()
+    {
+      isStopOnAssertModeEnabled_ = true;
+    }
+    
+    //-------------------------------------------------------------------------
+    bool Options::IsStopOnAssertModeEnabled() const
+    {
+      return isStopOnAssertModeEnabled_;
+    }
+
+    //-------------------------------------------------------------------------
 	void Options::AddExport(const OptionsExport& optionExport)
 	{
 		exports_.push_back(optionExport);

--- a/CppCoverage/Options.hpp
+++ b/CppCoverage/Options.hpp
@@ -61,6 +61,9 @@ namespace CppCoverage
 		void EnableCoverChildrenMode();
 		bool IsCoverChildrenModeEnabled() const;
 
+        void EnableStopOnAssertMode();
+        bool IsStopOnAssertModeEnabled() const;
+
 		void DisableAggregateByFileMode();
 		bool IsAggregateByFileModeEnabled() const;
 
@@ -101,8 +104,9 @@ namespace CppCoverage
 		bool isCoverChildrenModeEnabled_;
 		bool isAggregateByFileModeEnabled_;
 		bool isContinueAfterCppExceptionModeEnabled_;
-		bool isOptimizedBuildSupportEnabled_;
-		std::vector<OptionsExport> exports_;
+        bool isStopOnAssertModeEnabled_;
+        bool isOptimizedBuildSupportEnabled_;
+        std::vector<OptionsExport> exports_;
 		std::vector<boost::filesystem::path> inputCoveragePaths_;
 		std::vector<UnifiedDiffSettings> unifiedDiffSettingsCollection_;
 		std::vector<std::wstring> excludedLineRegexes_;

--- a/CppCoverage/OptionsParser.cpp
+++ b/CppCoverage/OptionsParser.cpp
@@ -476,6 +476,8 @@ namespace CppCoverage
 			options.EnableContinueAfterCppExceptionMode();
 		if (IsOptionSelected(variables, ProgramOptions::OptimizedBuildOption))
 			options.EnableOptimizedBuildSupport();
+        if (IsOptionSelected(variables, ProgramOptions::StopOnAssertOption))
+          options.EnableStopOnAssertMode();
 
 		AddExporTypes(variables, options);
 		AddInputCoverages(variables, options);

--- a/CppCoverage/ProgramOptions.cpp
+++ b/CppCoverage/ProgramOptions.cpp
@@ -96,7 +96,8 @@ namespace CppCoverage
 				(ProgramOptions::WorkingDirectoryOption.c_str(), po::value<std::string>(), "The program working directory.")
 				(ProgramOptions::CoverChildrenOption.c_str(), "Enable code coverage for children processes.")
 				(ProgramOptions::NoAggregateByFileOption.c_str(), "Do not aggregate coverage for same file path.")
-				(ProgramOptions::UnifiedDiffOption.c_str(),
+                (ProgramOptions::StopOnAssertOption.c_str(), "Do not continue after DebugBreak() or assert().")
+              (ProgramOptions::UnifiedDiffOption.c_str(),
 					po::value<T_Strings>()->composing(), GetUnifiedDiffHelp().c_str())
 				(ProgramOptions::ContinueAfterCppExceptionOption.c_str(), "Try to continue after throwing a C++ exception.")
 				(ProgramOptions::OptimizedBuildOption.c_str(), 
@@ -146,6 +147,7 @@ namespace CppCoverage
 	const std::string ProgramOptions::OptimizedBuildOption = "optimized_build";
 	const std::string ProgramOptions::ExcludedLineRegexOption = "excluded_line_regex";
 	const std::string ProgramOptions::SubstitutePdbSourcePathOption = "substitute_pdb_source_path";
+    const std::string ProgramOptions::StopOnAssertOption = "stop_on_assert";
 
 	//-------------------------------------------------------------------------
 	ProgramOptions::ProgramOptions()

--- a/CppCoverage/ProgramOptions.hpp
+++ b/CppCoverage/ProgramOptions.hpp
@@ -40,7 +40,8 @@ namespace CppCoverage
 		static const std::string WorkingDirectoryOption;
 		static const std::string CoverChildrenOption;
 		static const std::string NoAggregateByFileOption;
-		static const std::string ProgramToRunOption;
+        static const std::string StopOnAssertOption;
+        static const std::string ProgramToRunOption;
 		static const std::string ProgramToRunArgOption;
 		static const std::string ExportTypeOption;
 		static const std::string ExportTypeHtmlValue;

--- a/CppCoverage/RunCoverageSettings.cpp
+++ b/CppCoverage/RunCoverageSettings.cpp
@@ -50,7 +50,13 @@ namespace CppCoverage
 		continueAfterCppException_ = continueAfterCppException;
 	}
 	
-	//-------------------------------------------------------------------------
+    //-------------------------------------------------------------------------
+    void RunCoverageSettings::SetStopOnAssert(bool stopOnAssert)
+    {
+      stopOnAssert_ = stopOnAssert;
+    }
+
+    //-------------------------------------------------------------------------
 	void RunCoverageSettings::SetMaxUnmatchPathsForWarning(size_t maxUnmatchPathsForWarning)
 	{
 		maxUnmatchPathsForWarning_ = maxUnmatchPathsForWarning;
@@ -92,7 +98,13 @@ namespace CppCoverage
 		return continueAfterCppException_;
 	}
 	
-	//-------------------------------------------------------------------------
+    //-------------------------------------------------------------------------
+    bool RunCoverageSettings::GetStopOnAssert() const
+    {
+      return stopOnAssert_;
+    }
+    
+    //-------------------------------------------------------------------------
 	size_t RunCoverageSettings::GetMaxUnmatchPathsForWarning() const
 	{
 		return maxUnmatchPathsForWarning_;

--- a/CppCoverage/RunCoverageSettings.hpp
+++ b/CppCoverage/RunCoverageSettings.hpp
@@ -41,7 +41,8 @@ namespace CppCoverage
 
 		void SetCoverChildren(bool);
 		void SetContinueAfterCppException(bool);
-		void SetMaxUnmatchPathsForWarning(size_t);
+        void SetStopOnAssert(bool);
+        void SetMaxUnmatchPathsForWarning(size_t);
 		void SetOptimizedBuildSupport(bool);
 
 		const StartInfo& GetStartInfo() const;
@@ -49,7 +50,8 @@ namespace CppCoverage
 		const std::vector<UnifiedDiffSettings>& GetUnifiedDiffSettings() const;
 		bool GetCoverChildren() const;
 		bool GetContinueAfterCppException() const;
-		size_t GetMaxUnmatchPathsForWarning() const;
+        bool GetStopOnAssert() const;
+        size_t GetMaxUnmatchPathsForWarning() const;
 		bool GetOptimizedBuildSupport() const;
 		const std::vector<std::wstring>& GetExcludedLineRegexes() const;
 		const std::vector<SubstitutePdbSourcePath>& GetSubstitutePdbSourcePaths() const;
@@ -60,7 +62,8 @@ namespace CppCoverage
 		std::vector<UnifiedDiffSettings> unifiedDiffSettings_;
 		bool coverChildren_;
 		bool continueAfterCppException_;
-		size_t maxUnmatchPathsForWarning_;
+        bool stopOnAssert_;
+        size_t maxUnmatchPathsForWarning_;
 		bool optimizedBuildSupport_;
 		std::vector<std::wstring> excludedLineRegexes_;
 		std::vector<SubstitutePdbSourcePath> substitutePdbSourcePath_;

--- a/CppCoverageTest/DebuggerTest.cpp
+++ b/CppCoverageTest/DebuggerTest.cpp
@@ -30,7 +30,7 @@ namespace CppCoverageTest
 	TEST(DebugerTest, Debug)
 	{		
 		cov::StartInfo startInfo{ TestCoverageConsole::GetOutputBinaryPath() };
-		cov::Debugger debugger{ false, false };
+		cov::Debugger debugger{ false, false, false };
 		DebugEventsHandlerMock debugEventsHandlerMock;
 
 		EXPECT_CALL(debugEventsHandlerMock, OnCreateProcess(testing::_));

--- a/CppCoverageTest/ExceptionHandlerTest.cpp
+++ b/CppCoverageTest/ExceptionHandlerTest.cpp
@@ -38,7 +38,7 @@ namespace CppCoverageTest
 			void Run(const std::wstring& commandLineArgument)
 			{
 				cov::StartInfo startInfo{ TestCoverageConsole::GetOutputBinaryPath() };
-				cov::Debugger debugger{ false, false };
+				cov::Debugger debugger{ false, false, false };
 
 				startInfo.AddArgument(commandLineArgument);
 				debugger.Debug(startInfo, *this);

--- a/CppCoverageTest/OptionsParserTest.cpp
+++ b/CppCoverageTest/OptionsParserTest.cpp
@@ -125,7 +125,17 @@ namespace CppCoverageTest
 			->IsContinueAfterCppExceptionModeEnabled());
 	}
 
-	//-------------------------------------------------------------------------
+    //-------------------------------------------------------------------------
+    TEST(OptionsParserTest, StopOnAssert)
+    {
+      cov::OptionsParser parser;
+
+      ASSERT_TRUE(TestTools::Parse(parser,
+        { TestTools::GetOptionPrefix() + cov::ProgramOptions::StopOnAssertOption })
+        ->IsStopOnAssertModeEnabled());
+    }
+    
+    //-------------------------------------------------------------------------
 	TEST(OptionsParserTest, WorkingDirectory)
 	{
 		cov::OptionsParser parser;

--- a/CppCoverageTest/TestTools.cpp
+++ b/CppCoverageTest/TestTools.cpp
@@ -62,7 +62,7 @@ namespace CppCoverageTest
 		void GetHandles(const boost::filesystem::path& path, TestTools::T_HandlesFct action)
 		{
 			cov::StartInfo startInfo{ path };
-			cov::Debugger debugger{ false, false };
+			cov::Debugger debugger{ false, false, false };
 			DebugEventsHandler debugEventsHandler{ action };
 
 			debugger.Debug(startInfo, debugEventsHandler);

--- a/OpenCppCoverage/OpenCppCoverage.cpp
+++ b/OpenCppCoverage/OpenCppCoverage.cpp
@@ -149,7 +149,8 @@ namespace OpenCppCoverage
 
 				runCoverageSettings.SetCoverChildren(options.IsCoverChildrenModeEnabled());
 				runCoverageSettings.SetContinueAfterCppException(options.IsContinueAfterCppExceptionModeEnabled());
-				runCoverageSettings.SetMaxUnmatchPathsForWarning(maxUnmatchPathsForWarning);
+                runCoverageSettings.SetStopOnAssert(options.IsStopOnAssertModeEnabled());
+                runCoverageSettings.SetMaxUnmatchPathsForWarning(maxUnmatchPathsForWarning);
 				runCoverageSettings.SetOptimizedBuildSupport(options.IsOptimizedBuildSupportEnabled());
 				auto coverageData = codeCoverageRunner.RunCoverage(runCoverageSettings);
 				exitCode = coverageData.GetExitCode();


### PR DESCRIPTION
Added a command line option "stop_on_assert". It will cause the session to be stopped on DebugBreak() or assert().

Use case: there are some unit tests that, once asserted, end up in long loops of assertions. It is not normal that the program asserts, thus, there should be a way to stop profiling.