### PR TITLE
Add SonarQube Generic Coverage format as an export option

### DIFF
--- a/CppCoverage/OptionsExport.cpp
+++ b/CppCoverage/OptionsExport.cpp
@@ -48,6 +48,7 @@ namespace CppCoverage
 		static const std::map<OptionsExportType, std::wstring> optionsExportTypeTexts =
 		{ { OptionsExportType::Html, L"Html" },
 		{ OptionsExportType::Cobertura, L"Cobertura" },
+		{ OptionsExportType::SonarQube, L"SonarQube" },
 		{ OptionsExportType::Binary, L"Binary" } };
 
 		return optionsExportTypeTexts.at(type_);

--- a/CppCoverage/OptionsParser.cpp
+++ b/CppCoverage/OptionsParser.cpp
@@ -383,6 +383,8 @@ namespace CppCoverage
 		                     OptionsExportType::Html);
 		exportTypes_.emplace(ProgramOptions::ExportTypeCoberturaValue,
 		                     OptionsExportType::Cobertura);
+		exportTypes_.emplace(ProgramOptions::ExportTypeSonarQubeValue,
+		                     OptionsExportType::SonarQube);
 		exportTypes_.emplace(ProgramOptions::ExportTypeBinaryValue,
 		                     OptionsExportType::Binary);
 

--- a/CppCoverage/ProgramOptions.cpp
+++ b/CppCoverage/ProgramOptions.cpp
@@ -46,12 +46,14 @@ namespace CppCoverage
 			return "Format: <exportType>:<outputPath>.\n"
 			       "<exportType> can be: " +
 			       ProgramOptions::ExportTypeHtmlValue + ", " +
-			       ProgramOptions::ExportTypeCoberturaValue + " or " +
+			       ProgramOptions::ExportTypeCoberturaValue + ", " +
+			       ProgramOptions::ExportTypeSonarQubeValue + " or " +
 			       ProgramOptions::ExportTypeBinaryValue +
 			       "\n<outputPath> (optional) export output path.\n"
 			       "Must be a folder for " +
 			       ProgramOptions::ExportTypeHtmlValue + " and a file for " +
-			       ProgramOptions::ExportTypeCoberturaValue + " or " +
+			       ProgramOptions::ExportTypeCoberturaValue + ", " +
+			       ProgramOptions::ExportTypeSonarQubeValue + " or " +
 			       ProgramOptions::ExportTypeBinaryValue +
 			       ".\nExample: html:MyFolder\\MySubFolder\n"
 			       "This flag can have multiple occurrences.";
@@ -139,6 +141,7 @@ namespace CppCoverage
 	const std::string ProgramOptions::ExportTypeOption = "export_type";
 	const std::string ProgramOptions::ExportTypeHtmlValue = "html";
 	const std::string ProgramOptions::ExportTypeCoberturaValue = "cobertura";
+	const std::string ProgramOptions::ExportTypeSonarQubeValue = "sonarqube";
 	const std::string ProgramOptions::ExportTypeBinaryValue = "binary";
 	const std::string ProgramOptions::InputCoverageValue = "input_coverage";
 	const std::string ProgramOptions::UnifiedDiffOption = "unified_diff";

--- a/CppCoverage/ProgramOptions.hpp
+++ b/CppCoverage/ProgramOptions.hpp
@@ -44,7 +44,8 @@ namespace CppCoverage
 		static const std::string ProgramToRunArgOption;
 		static const std::string ExportTypeOption;
 		static const std::string ExportTypeHtmlValue;
-		static const std::string ExportTypeCoberturaValue;	
+		static const std::string ExportTypeCoberturaValue;
+		static const std::string ExportTypeSonarQubeValue;
 		static const std::string ExportTypeBinaryValue;
 		static const std::string InputCoverageValue;
 		static const std::string UnifiedDiffOption;

--- a/CppCoverageTest/OptionsParserExportTest.cpp
+++ b/CppCoverageTest/OptionsParserExportTest.cpp
@@ -86,11 +86,43 @@ namespace CppCoverageTest
 	}
 
 	//-------------------------------------------------------------------------
-	TEST(OptionsParserExportTest, ExportTypesBoth)
+	TEST(OptionsParserExportTest, ExportTypesSonarQubeValue)
+	{
+		TestExportTypes(
+			{ cov::ProgramOptions::ExportTypeSonarQubeValue },
+			{ cov::OptionsExport{ cov::OptionsExportType::SonarQube } });
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(OptionsParserExportTest, ExportTypesHtmlAndCobertura)
 	{
 		TestExportTypes(
 		{ cov::ProgramOptions::ExportTypeHtmlValue, cov::ProgramOptions::ExportTypeCoberturaValue },
 		{ cov::OptionsExport{ cov::OptionsExportType::Html }, cov::OptionsExport{ cov::OptionsExportType::Cobertura } });
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(OptionsParserExportTest, ExportTypesHtmlAndSonarQube)
+	{
+		TestExportTypes(
+			{ cov::ProgramOptions::ExportTypeHtmlValue, cov::ProgramOptions::ExportTypeSonarQubeValue },
+			{ cov::OptionsExport{ cov::OptionsExportType::Html }, cov::OptionsExport{ cov::OptionsExportType::SonarQube } });
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(OptionsParserExportTest, ExportTypesCoberturaAndSonarQube)
+	{
+		TestExportTypes(
+			{ cov::ProgramOptions::ExportTypeCoberturaValue, cov::ProgramOptions::ExportTypeSonarQubeValue },
+			{ cov::OptionsExport{ cov::OptionsExportType::Cobertura }, cov::OptionsExport{ cov::OptionsExportType::SonarQube } });
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(OptionsParserExportTest, ExportTypesAll)
+	{
+		TestExportTypes(
+			{ cov::ProgramOptions::ExportTypeHtmlValue, cov::ProgramOptions::ExportTypeCoberturaValue, cov::ProgramOptions::ExportTypeSonarQubeValue },
+			{ cov::OptionsExport{ cov::OptionsExportType::Html }, cov::OptionsExport{ cov::OptionsExportType::Cobertura }, cov::OptionsExport{ cov::OptionsExportType::SonarQube } });
 	}
 
 	//-------------------------------------------------------------------------

--- a/Exporter/Exporter.vcxproj
+++ b/Exporter/Exporter.vcxproj
@@ -189,6 +189,7 @@
     <ClInclude Include="Html\TemplateHtmlExporter.hpp" />
     <ClInclude Include="IExporter.hpp" />
     <ClInclude Include="InvalidOutputFileException.hpp" />
+    <ClInclude Include="SonarQubeExporter.hpp" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
@@ -217,6 +218,7 @@
     <ClCompile Include="Html\HtmlFolderStructure.cpp" />
     <ClCompile Include="Html\TemplateHtmlExporter.cpp" />
     <ClCompile Include="InvalidOutputFileException.cpp" />
+    <ClCompile Include="SonarQubeExporter.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/Exporter/SonarQubeExporter.cpp
+++ b/Exporter/SonarQubeExporter.cpp
@@ -1,0 +1,134 @@
+// OpenCppCoverage is an open source code coverage for C++.
+// Copyright (C) 2014 OpenCppCoverage
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "stdafx.h"
+
+#include <codecvt>
+#include <unordered_set>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <boost/filesystem.hpp>
+
+#include "SonarQubeExporter.hpp"
+#include "CppCoverage/CoverageData.hpp"
+#include "CppCoverage/ModuleCoverage.hpp"
+#include "CppCoverage/FileCoverage.hpp"
+#include "CppCoverage/LineCoverage.hpp"
+#include "CppCoverage/CoverageRateComputer.hpp"
+#include "InvalidOutputFileException.hpp"
+
+#include "Tools/Tool.hpp"
+
+namespace cov = CppCoverage;
+namespace property_tree = boost::property_tree;
+namespace fs = boost::filesystem;
+
+namespace Exporter
+{
+	namespace
+	{
+		//-------------------------------------------------------------------------
+		std::wstring GetSafeFilePath(fs::path path)
+		{
+#ifdef _WIN32
+			// SonarQube is case sensitive.
+			// Find the "case correct" version of the path.
+			WCHAR winPath[MAX_PATH];
+			DWORD dwMax = MAX_PATH;
+			HANDLE winHandle = FindFirstFileNameW(path.c_str(), 0, &dwMax, winPath);
+			if (winHandle != INVALID_HANDLE_VALUE)
+			{
+				path = path.root_name() / fs::path(winPath);
+				FindClose(winHandle);
+			}
+#endif
+			// Set locale for conversion from UTF-8 to UTF-16.
+			path.imbue(std::locale(std::locale(), new std::codecvt_utf8_utf16<wchar_t>()));
+			return path.wstring();
+		}
+
+		//-------------------------------------------------------------------------
+		void FillCoverageTree(
+			property_tree::wptree& root,
+			const CppCoverage::CoverageData& coverageData)
+		{
+			auto& coverageTree = root.add_child(L"coverage", property_tree::wptree{});
+			coverageTree.put(L"<xmlattr>.version", 1);
+
+			for (const auto& module : coverageData.GetModules())
+			{
+				// Ignore empty modules
+				if (module->GetFiles().empty())
+					continue;
+
+				const auto& modulePath = module->GetPath();
+				for (const auto& file : module->GetFiles())
+				{
+					// Ignore empty files
+					if (file->GetLines().empty())
+						continue;
+
+					auto& fileTree = coverageTree.add_child(L"file", property_tree::wptree{});
+					auto path = GetSafeFilePath(file->GetPath());
+					fileTree.put(L"<xmlattr>.path", path);
+
+					for (const auto& line : file->GetLines())
+					{
+						auto& lineTree = fileTree.add_child(L"lineToCover", property_tree::wptree{});
+						lineTree.put(L"<xmlattr>.lineNumber", line.GetLineNumber());
+						lineTree.put(L"<xmlattr>.covered", line.HasBeenExecuted() ? true : false);
+					}
+				}
+			}
+		}
+	}
+
+	//-------------------------------------------------------------------------
+	SonarQubeExporter::SonarQubeExporter() = default;
+
+	//-------------------------------------------------------------------------
+	boost::filesystem::path SonarQubeExporter::GetDefaultPath(const std::wstring& prefix) const
+	{
+		boost::filesystem::path path{ prefix };
+		path += "Coverage.xml";
+		return path;
+	}
+
+	//-------------------------------------------------------------------------
+	void SonarQubeExporter::Export(
+		const CppCoverage::CoverageData& coverageData,
+		const boost::filesystem::path& output)
+	{
+		Tools::CreateParentFolderIfNeeded(output);
+		std::wofstream ofs{ output.string().c_str() };
+		if (!ofs)
+			throw InvalidOutputFileException(output, "sonarqube");
+		Export(coverageData, ofs);
+		Tools::ShowOutputMessage(L"SonarQube report generated: ", output);
+	}
+
+	//-------------------------------------------------------------------------
+	void SonarQubeExporter::Export(
+		const CppCoverage::CoverageData& coverageData,
+		std::wostream& ostream) const
+	{
+		using Ptree = property_tree::wptree;
+		Ptree root;
+		FillCoverageTree(root, coverageData);
+		property_tree::xml_writer_settings<Ptree::key_type> settings(' ', 2);
+		property_tree::xml_parser::write_xml(ostream, root, settings);
+	}
+}

--- a/Exporter/SonarQubeExporter.hpp
+++ b/Exporter/SonarQubeExporter.hpp
@@ -16,39 +16,35 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
-#include <boost/filesystem.hpp>
+#include <iosfwd>
 
-#include "CppCoverageExport.hpp"
+#include "ExporterExport.hpp"
+#include "IExporter.hpp"
 
 namespace CppCoverage
 {
-	enum class OptionsExportType
-	{
-		Html,
-		Cobertura,
-		SonarQube,
-		Binary
-	};
-
-	class CPPCOVERAGE_DLL OptionsExport
-	{
-	public:
-		explicit OptionsExport(OptionsExportType type);
-		OptionsExport(OptionsExportType type, const boost::filesystem::path&);
-
-		OptionsExport(const OptionsExport&) = default;
-		OptionsExport& operator=(const OptionsExport&) = default;
-		
-		OptionsExportType GetType() const;
-		const std::wstring& GetTypeString() const;
-		const boost::optional<boost::filesystem::path>& GetOutputPath() const;
-
-		friend std::wostream& operator<<(std::wostream& ostr, const OptionsExport&);
-
-	private:
-		OptionsExportType type_;
-		boost::optional<boost::filesystem::path> outputPath_;
-	};
+	class CoverageData;
 }
 
+namespace boost
+{
+	namespace filesystem
+	{
+		class path;
+	}
+}
+
+namespace Exporter
+{
+	class EXPORTER_DLL SonarQubeExporter : public IExporter
+	{
+	public:
+		SonarQubeExporter();
+		boost::filesystem::path GetDefaultPath(const std::wstring& runningCommandFilename) const override;
+		void Export(const CppCoverage::CoverageData&, const boost::filesystem::path& output) override;
+		void Export(const CppCoverage::CoverageData&, std::wostream&) const;
+	private:
+		SonarQubeExporter(const SonarQubeExporter&) = delete;
+		SonarQubeExporter& operator=(const SonarQubeExporter&) = delete;
+	};
+}

--- a/ExporterTest/Data/SonarQubeExporterExpectedResult.xml
+++ b/ExporterTest/Data/SonarQubeExporterExpectedResult.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage version="1">
+  <file path="File">
+    <lineToCover lineNumber="0" covered="true"/>
+    <lineToCover lineNumber="1" covered="false"/>
+  </file>
+  <file path="Directory/File2">
+    <lineToCover lineNumber="0" covered="true"/>
+  </file>
+</coverage>

--- a/ExporterTest/ExporterTest.vcxproj
+++ b/ExporterTest/ExporterTest.vcxproj
@@ -189,6 +189,7 @@
     <ClCompile Include="HtmlExporterTest.cpp" />
     <ClCompile Include="HtmlFileCoverageExporterTest.cpp" />
     <ClCompile Include="HtmlFolderStructureTest.cpp" />
+    <ClCompile Include="SonarQubeExporterTest.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -215,6 +216,7 @@
     <Xml Include="Data\CoberturaExporterExpectedResult.xml">
       <SubType>Designer</SubType>
     </Xml>
+    <Xml Include="Data\SonarQubeExporterExpectedResult.xml" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/ExporterTest/SonarQubeExporterTest.cpp
+++ b/ExporterTest/SonarQubeExporterTest.cpp
@@ -1,0 +1,125 @@
+// OpenCppCoverage is an open source code coverage for C++.
+// Copyright (C) 2014 OpenCppCoverage
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "stdafx.h"
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+
+#include "CppCoverage/CoverageData.hpp"
+#include "CppCoverage/ModuleCoverage.hpp"
+#include "CppCoverage/FileCoverage.hpp"
+
+#include "Exporter/InvalidOutputFileException.hpp"
+#include "Exporter/SonarQubeExporter.hpp"
+#include "tools/Tool.hpp"
+
+#include "TestHelper/TemporaryPath.hpp"
+
+namespace cov = CppCoverage;
+namespace fs = boost::filesystem;
+
+namespace ExporterTest
+{
+	namespace
+	{
+		//-------------------------------------------------------------------------
+		std::wstring GetExpectedResult()
+		{
+			fs::path expectedResult = fs::path(PROJECT_DIR) / "Data" / "SonarQubeExporterExpectedResult.xml";
+			std::wifstream ifs{ expectedResult.wstring().c_str() };
+			std::wostringstream ostr;
+			ostr << ifs.rdbuf();
+			return ostr.str();
+		}
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(SonarQubeExporterTest, Export)
+	{
+		cov::CoverageData coverageData{ L"", 0 };
+		coverageData.AddModule(L"EmptyModule");
+
+		auto& module = coverageData.AddModule(L"Module");
+		module.AddFile("EmptyFile");
+
+		auto& file = module.AddFile("File");
+		file.AddLine(0, true);
+		file.AddLine(1, false);
+
+		module.AddFile("Directory/File2").AddLine(0, true);
+
+		std::wostringstream ostr;
+		Exporter::SonarQubeExporter().Export(coverageData, ostr);
+		auto result = ostr.str();
+		auto expectedResult = GetExpectedResult();
+		ASSERT_EQ(result, expectedResult);
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(SonarQubeExporterTest, SubFolderDoesNotExist)
+	{
+		cov::CoverageData coverageData{ L"", 0 };
+		TestHelper::TemporaryPath output;
+		auto outputPath = output.GetPath() / "SubFolder" / "output.xml";
+		ASSERT_FALSE(fs::exists(outputPath));
+		Exporter::SonarQubeExporter().Export(coverageData, outputPath);
+		ASSERT_TRUE(fs::exists(outputPath));
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(SonarQubeExporterTest, SpecialChars)
+	{
+		cov::CoverageData coverageData{ L"", 0 };
+		coverageData.AddModule(L"יא").AddFile(L"אי/יא").AddLine(0, true);
+		std::wostringstream ostr;
+		Exporter::SonarQubeExporter().Export(coverageData, ostr);
+		auto result = ostr.str();
+		auto filename = L"\u00e0\u00e9\u002f\u00e9\u00e0"; // אי/יא in UTF-8
+		ASSERT_TRUE(boost::algorithm::contains(result, filename));
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(SonarQubeExporterTest, OutputExists)
+	{
+		cov::CoverageData coverageData{ L"", 0 };
+		TestHelper::TemporaryPath outputPath{ TestHelper::TemporaryPathOption::CreateAsFile };
+		ASSERT_NO_THROW(Exporter::SonarQubeExporter().Export(coverageData, outputPath));
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(SonarQubeExporterTest, InvalidFile)
+	{
+		cov::CoverageData coverageData{ L"", 0 };
+		TestHelper::TemporaryPath outputPath{
+			TestHelper::TemporaryPathOption::CreateAsFolder };
+		ASSERT_THROW(Exporter::SonarQubeExporter().Export(
+			coverageData, outputPath.GetPath() / "InvalidFile/"),
+			Exporter::InvalidOutputFileException);
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(SonarQubeExporterTest, PathCase)
+	{
+		cov::CoverageData coverageData{ L"", 0 };
+		coverageData.AddModule(L"My Module").AddFile(L"My Directory/My File").AddLine(0, true);
+		std::wostringstream ostr;
+		Exporter::SonarQubeExporter().Export(coverageData, ostr);
+		auto result = ostr.str();
+		auto filename = L"\"My Directory/My File\"";
+		ASSERT_TRUE(boost::algorithm::contains(result, filename));
+	}
+}

--- a/OpenCppCoverage/OpenCppCoverage.cpp
+++ b/OpenCppCoverage/OpenCppCoverage.cpp
@@ -30,6 +30,7 @@
 
 #include "Exporter/Html/HtmlExporter.hpp"
 #include "Exporter/CoberturaExporter.hpp"
+#include "Exporter/SonarQubeExporter.hpp"
 #include "Exporter/Binary/BinaryExporter.hpp"
 #include "Exporter/Binary/CoverageDataDeserializer.hpp"
 
@@ -70,8 +71,10 @@ namespace OpenCppCoverage
 			
 			exporters.emplace(cov::OptionsExportType::Html, 
 				std::unique_ptr<Exporter::IExporter>(new Exporter::HtmlExporter{ Tools::GetTemplateFolder() }));
-			exporters.emplace(cov::OptionsExportType::Cobertura, 
+			exporters.emplace(cov::OptionsExportType::Cobertura,
 				std::unique_ptr<Exporter::IExporter>(new Exporter::CoberturaExporter{}));
+			exporters.emplace(cov::OptionsExportType::SonarQube,
+				std::unique_ptr<Exporter::IExporter>(new Exporter::SonarQubeExporter{}));
 			exporters.emplace(cov::OptionsExportType::Binary,
 				std::unique_ptr<Exporter::IExporter>(new Exporter::BinaryExporter{}));
 			

--- a/OpenCppCoverageTest/ImportExportTests.cpp
+++ b/OpenCppCoverageTest/ImportExportTests.cpp
@@ -86,6 +86,12 @@ namespace OpenCppCoverageTest
 	}
 
 	//-------------------------------------------------------------------------
+	TEST(ImportExportTest, ExportSonarQube)
+	{
+		RunCoverage(cov::ProgramOptions::ExportTypeSonarQubeValue);
+	}
+
+	//-------------------------------------------------------------------------
 	TEST(ImportExportTest, ExportImportBinary)
 	{
 		TestHelper::TemporaryPath initialOutput;


### PR DESCRIPTION
Hi OpenCppCoverage,
Great tool you've created.
I've added [SonarQube's Generic Code Coverage format](https://docs.sonarqube.org/display/SONAR/Generic+Test+Data) as an export option.
I've mostly just followed how the Corbertura export option was implemented.
All unit tests are passing for me on Windows with the exception of the VS2013 optimized test (I was developing on VS2017).
I've done some manual integration testing with SonarQube 7.2.1 and all looks good.
Note [SonarQube is case sensitive for paths](http://sonarqube-archive.15.x6.nabble.com/Case-Sensitive-resource-names-on-windows-td5023260.html), so there is a bit of trickery in GetSafeFilePath to lookup the Windows "correct case".
Let me know if there is anything I can do to help get the feature into the main repo.