### PR TITLE
Hide the debugger in the PEB of the debuggee to prevent heap tracing and other non-conventional behavior

### DIFF
--- a/CppCoverage/CodeCoverageRunner.cpp
+++ b/CppCoverage/CodeCoverageRunner.cpp
@@ -79,6 +79,8 @@ namespace CppCoverage
 		    std::make_unique<DebugInformationEnumerator>(settings.GetSubstitutePdbSourcePaths()),
 			filterAssistant_);
 
+		exceptionHandler_->SetHideDebugger(settings.GetHideDebugger());
+
 		const auto& startInfo = settings.GetStartInfo();
 		int exitCode = debugger.Debug(startInfo, *this);
 		const auto& path = startInfo.GetPath();

--- a/CppCoverage/CppCoverage.vcxproj
+++ b/CppCoverage/CppCoverage.vcxproj
@@ -169,6 +169,7 @@
     <ClInclude Include="CoverageData.hpp" />
     <ClInclude Include="CoverageDataMerger.hpp" />
     <ClInclude Include="CoverageFilterManager.hpp" />
+    <ClInclude Include="DebugHider.hpp" />
     <ClInclude Include="DebugInformationEnumerator.hpp" />
     <ClInclude Include="FileSystem.hpp" />
     <ClInclude Include="FilterAssistant.hpp" />

--- a/CppCoverage/CppCoverage.vcxproj
+++ b/CppCoverage/CppCoverage.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{A50DD5A6-E85A-4E0B-9CC6-90D32503CE62}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>CppCoverage</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/CppCoverage/DebugHider.hpp
+++ b/CppCoverage/DebugHider.hpp
@@ -1,0 +1,311 @@
+#pragma once
+
+#include <Windows.h>
+#include <vector>
+
+namespace CppCoverage
+{
+	///////////////////////////////////////////////////////////////////////////////////////
+	//Evolution of Process Environment Block (PEB) http://blog.rewolf.pl/blog/?p=573
+	//March 2, 2013 / ReWolf posted in programming, reverse engineering, source code, x64 /
+
+	template <class T>
+	struct LIST_ENTRY_T
+	{
+		T Flink;
+		T Blink;
+	};
+
+	template <class T>
+	struct UNICODE_STRING_T
+	{
+		union
+		{
+			struct
+			{
+				WORD Length;
+				WORD MaximumLength;
+			};
+			T dummy;
+		};
+		T _Buffer;
+	};
+
+	template <class T, class NGF, int A>
+	struct _PEB_T
+	{
+		union
+		{
+			struct
+			{
+				BYTE InheritedAddressSpace;
+				BYTE ReadImageFileExecOptions;
+				BYTE BeingDebugged;
+				BYTE _SYSTEM_DEPENDENT_01;
+			};
+			T dummy01;
+		};
+		T Mutant;
+		T ImageBaseAddress;
+		T Ldr;
+		T ProcessParameters;
+		T SubSystemData;
+		T ProcessHeap;
+		T FastPebLock;
+		T _SYSTEM_DEPENDENT_02;
+		T _SYSTEM_DEPENDENT_03;
+		T _SYSTEM_DEPENDENT_04;
+		union
+		{
+			T KernelCallbackTable;
+			T UserSharedInfoPtr;
+		};
+		DWORD SystemReserved;
+		DWORD _SYSTEM_DEPENDENT_05;
+		T _SYSTEM_DEPENDENT_06;
+		T TlsExpansionCounter;
+		T TlsBitmap;
+		DWORD TlsBitmapBits[2];
+		T ReadOnlySharedMemoryBase;
+		T _SYSTEM_DEPENDENT_07;
+		T ReadOnlyStaticServerData;
+		T AnsiCodePageData;
+		T OemCodePageData;
+		T UnicodeCaseTableData;
+		DWORD NumberOfProcessors;
+		union
+		{
+			DWORD NtGlobalFlag;
+			NGF dummy02;
+		};
+		LARGE_INTEGER CriticalSectionTimeout;
+		T HeapSegmentReserve;
+		T HeapSegmentCommit;
+		T HeapDeCommitTotalFreeThreshold;
+		T HeapDeCommitFreeBlockThreshold;
+		DWORD NumberOfHeaps;
+		DWORD MaximumNumberOfHeaps;
+		T ProcessHeaps;
+	};
+
+	typedef _PEB_T<DWORD, DWORD64, 34> PEB32;
+	typedef _PEB_T<DWORD64, DWORD, 30> PEB64;
+
+#ifdef _WIN64
+	typedef PEB64 PEB_CURRENT;
+#else
+	typedef PEB32 PEB_CURRENT;
+#endif
+
+	//Quote from The Ultimate Anti-Debugging Reference by Peter Ferrie
+	//Flags field exists at offset 0x0C in the heap on the 32-bit versions of Windows NT, Windows 2000, and Windows XP; and at offset 0x40 on the 32-bit versions of Windows Vista and later.
+	//Flags field exists at offset 0x14 in the heap on the 64-bit versions of Windows XP, and at offset 0x70 in the heap on the 64-bit versions of Windows Vista and later.
+	//ForceFlags field exists at offset 0x10 in the heap on the 32-bit versions of Windows NT, Windows 2000, and Windows XP; and at offset 0x44 on the 32-bit versions of Windows Vista and later.
+	//ForceFlags field exists at offset 0x18 in the heap on the 64-bit versions of Windows XP, and at offset 0x74 in the heap on the 64-bit versions of Windows Vista and later.
+
+	static bool IsWindowsVersionOrGreater(WORD wMajorVersion, WORD wMinorVersion, WORD wServicePackMajor)
+	{
+		OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
+		DWORDLONG        const dwlConditionMask = VerSetConditionMask(
+			VerSetConditionMask(
+				VerSetConditionMask(
+					0, VER_MAJORVERSION, VER_GREATER_EQUAL),
+				VER_MINORVERSION, VER_GREATER_EQUAL),
+			VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
+
+		osvi.dwMajorVersion = wMajorVersion;
+		osvi.dwMinorVersion = wMinorVersion;
+		osvi.wServicePackMajor = wServicePackMajor;
+
+		return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
+	}
+
+	static bool IsWindowsVistaOrGreater()
+	{
+		return IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_VISTA), LOBYTE(_WIN32_WINNT_VISTA), 0);
+	}
+
+	static int getHeapFlagsOffset(bool x64)
+	{
+		if (x64)  //x64 offsets
+		{
+			if (IsWindowsVistaOrGreater())
+			{
+				return 0x70;
+			}
+			else
+			{
+				return 0x14;
+			}
+		}
+		else //x86 offsets
+		{
+			if (IsWindowsVistaOrGreater())
+			{
+				return 0x40;
+			}
+			else
+			{
+				return 0x0C;
+			}
+		}
+	}
+
+	static int getHeapForceFlagsOffset(bool x64)
+	{
+		if (x64)  //x64 offsets
+		{
+			if (IsWindowsVistaOrGreater())
+			{
+				return 0x74;
+			}
+			else
+			{
+				return 0x18;
+			}
+		}
+		else //x86 offsets
+		{
+			if (IsWindowsVistaOrGreater())
+			{
+				return 0x44;
+			}
+			else
+			{
+				return 0x10;
+			}
+		}
+	}
+
+	typedef struct _PROCESS_BASIC_INFORMATION
+	{
+		PVOID Reserved1;
+		PVOID PebBaseAddress;
+		PVOID Reserved2[2];
+		ULONG_PTR UniqueProcessId;
+		PVOID Reserved3;
+	} PROCESS_BASIC_INFORMATION;
+
+	typedef ULONG (NTAPI *p_NtQueryInformationProcess)(
+		HANDLE /* ProcessHandle */,
+		ULONG /* ProcessInformationClass */,
+		PVOID /* ProcessInformation */,
+		ULONG /* ProcessInformationLength */,
+		PULONG /* ReturnLength */
+		);
+
+	static void* GetPEBLocation(HANDLE hProcess)
+	{
+		static auto NtQueryInformationProcess = (p_NtQueryInformationProcess)GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "NtQueryInformationProcess");
+		if (!NtQueryInformationProcess)
+			return nullptr;
+
+		ULONG RequiredLen = 0;
+		void* PebAddress = nullptr;
+		PROCESS_BASIC_INFORMATION myProcessBasicInformation[5] = { 0 };
+
+		if (NtQueryInformationProcess(hProcess, 0 /* ProcessBasicInformation */, myProcessBasicInformation, sizeof(PROCESS_BASIC_INFORMATION), &RequiredLen) == 0)
+		{
+			PebAddress = (void*)myProcessBasicInformation->PebBaseAddress;
+		}
+		else
+		{
+			if (NtQueryInformationProcess(hProcess, 0 /* ProcessBasicInformation */, myProcessBasicInformation, RequiredLen, &RequiredLen) == 0)
+			{
+				PebAddress = (void*)myProcessBasicInformation->PebBaseAddress;
+			}
+		}
+
+		return PebAddress;
+	}
+
+	static bool PebPatchHeapFlags(PEB_CURRENT* peb, HANDLE hProcess)
+	{
+#ifdef _WIN64
+		const auto is_x64 = true;
+#else
+		const auto is_x64 = false;
+#endif
+
+		std::vector<PVOID> heaps;
+		heaps.resize(peb->NumberOfHeaps);
+
+		if (ReadProcessMemory(hProcess, (PVOID)peb->ProcessHeaps, (PVOID)heaps.data(), heaps.size() * sizeof(PVOID), nullptr) == FALSE)
+			return false;
+
+		std::basic_string<uint8_t> heap;
+		heap.resize(0x100); // hacky
+		for (DWORD i = 0; i < peb->NumberOfHeaps; i++)
+		{
+			if (ReadProcessMemory(hProcess, heaps[i], (PVOID)heap.data(), heap.size(), nullptr) == FALSE)
+				return false;
+
+			auto flags = (DWORD *)(heap.data() + getHeapFlagsOffset(is_x64));
+			auto force_flags = (DWORD *)(heap.data() + getHeapForceFlagsOffset(is_x64));
+
+			if (i == 0)
+			{
+				// Default heap.
+				*flags &= HEAP_GROWABLE;
+			}
+			else
+			{
+				// Flags from RtlCreateHeap/HeapCreate.
+				*flags &= (HEAP_GROWABLE | HEAP_GENERATE_EXCEPTIONS | HEAP_NO_SERIALIZE | HEAP_CREATE_ENABLE_EXECUTE);
+			}
+
+			*force_flags = 0;
+
+			if (WriteProcessMemory(hProcess, heaps[i], (PVOID)heap.data(), heap.size(), nullptr) == FALSE)
+				return false;
+		}
+
+		return true;
+	}
+
+	static bool HidePebInProcess(HANDLE hProcess)
+	{
+		PEB_CURRENT myPEB = { 0 };
+		SIZE_T ueNumberOfBytesRead = 0;
+		void* heapFlagsAddress = 0;
+		DWORD heapFlags = 0;
+		void* heapForceFlagsAddress = 0;
+		DWORD heapForceFlags = 0;
+
+		void* AddressOfPEB = GetPEBLocation(hProcess);
+
+		if (!AddressOfPEB)
+			return false;
+
+		if (ReadProcessMemory(hProcess, AddressOfPEB, (void*)&myPEB, sizeof(PEB_CURRENT), &ueNumberOfBytesRead))
+		{
+			myPEB.BeingDebugged = FALSE;
+			myPEB.NtGlobalFlag &= ~0x70;
+
+#ifdef _WIN64
+			heapFlagsAddress = (void*)((LONG_PTR)myPEB.ProcessHeap + getHeapFlagsOffset(true));
+			heapForceFlagsAddress = (void*)((LONG_PTR)myPEB.ProcessHeap + getHeapForceFlagsOffset(true));
+#else
+			heapFlagsAddress = (void*)((LONG_PTR)myPEB.ProcessHeap + getHeapFlagsOffset(false));
+			heapForceFlagsAddress = (void*)((LONG_PTR)myPEB.ProcessHeap + getHeapForceFlagsOffset(false));
+#endif //_WIN64
+
+			ReadProcessMemory(hProcess, heapFlagsAddress, &heapFlags, sizeof(DWORD), 0);
+			ReadProcessMemory(hProcess, heapForceFlagsAddress, &heapForceFlags, sizeof(DWORD), 0);
+
+			heapFlags &= HEAP_GROWABLE;
+			heapForceFlags = 0;
+
+			WriteProcessMemory(hProcess, heapFlagsAddress, &heapFlags, sizeof(DWORD), 0);
+			WriteProcessMemory(hProcess, heapForceFlagsAddress, &heapForceFlags, sizeof(DWORD), 0);
+
+			PebPatchHeapFlags(&myPEB, hProcess);
+
+			if (WriteProcessMemory(hProcess, AddressOfPEB, (void*)&myPEB, sizeof(PEB_CURRENT), &ueNumberOfBytesRead))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/CppCoverage/ExceptionHandler.cpp
+++ b/CppCoverage/ExceptionHandler.cpp
@@ -20,6 +20,7 @@
 
 #include "Tools/ScopedAction.hpp"
 #include "Tools/Tool.hpp"
+#include "DebugHider.hpp"
 
 namespace CppCoverage
 {
@@ -84,7 +85,10 @@ namespace CppCoverage
 				auto& processHandles = it->second;
 				// Breakpoint exception need to be ignore the first time by process.
 				if (std::find(processHandles.begin(), processHandles.end(), hProcess) == processHandles.end())
+				{
+					HidePebInProcess(hProcess);
 					processHandles.push_back(hProcess);
+				}
 				else
 					return ExceptionHandlerStatus::BreakPoint;
 			}

--- a/CppCoverage/ExceptionHandler.cpp
+++ b/CppCoverage/ExceptionHandler.cpp
@@ -34,6 +34,7 @@ namespace CppCoverage
 
 	//-------------------------------------------------------------------------
 	ExceptionHandler::ExceptionHandler()
+		: hideDebugger_{ false }
 	{
 		breakPointExceptionCode_.emplace(EXCEPTION_BREAKPOINT, std::vector<HANDLE>{});
 		breakPointExceptionCode_.emplace(ExceptionEmulationX86ErrorCode, std::vector<HANDLE>{});
@@ -86,7 +87,8 @@ namespace CppCoverage
 				// Breakpoint exception need to be ignore the first time by process.
 				if (std::find(processHandles.begin(), processHandles.end(), hProcess) == processHandles.end())
 				{
-					HidePebInProcess(hProcess);
+					if (hideDebugger_)
+						HidePebInProcess(hProcess);
 					processHandles.push_back(hProcess);
 				}
 				else
@@ -120,6 +122,12 @@ namespace CppCoverage
 			if (it != processes.end())
 				processes.erase(it);
 		}
+	}
+
+	//-------------------------------------------------------------------------
+	void ExceptionHandler::SetHideDebugger(bool hideDebugger)
+	{
+		hideDebugger_ = hideDebugger;
 	}
 
 	//-------------------------------------------------------------------------

--- a/CppCoverage/ExceptionHandler.hpp
+++ b/CppCoverage/ExceptionHandler.hpp
@@ -47,6 +47,7 @@ namespace CppCoverage
 
 		ExceptionHandlerStatus HandleException(HANDLE hProcess, const EXCEPTION_DEBUG_INFO&, std::wostream&);
 		void OnExitProcess(HANDLE hProcess);
+		void SetHideDebugger(bool hideDebugger);
 
 	private:
 		ExceptionHandler(const ExceptionHandler&) = delete;
@@ -57,6 +58,7 @@ namespace CppCoverage
 
 		std::unordered_map<DWORD, std::wstring> exceptionCode_;
 		std::map<DWORD, std::vector<HANDLE>> breakPointExceptionCode_;
+		bool hideDebugger_;
 	};
 }
 

--- a/CppCoverage/Options.cpp
+++ b/CppCoverage/Options.cpp
@@ -49,6 +49,7 @@ namespace CppCoverage
 		, isAggregateByFileModeEnabled_{true}
 		, isContinueAfterCppExceptionModeEnabled_{false}
 		, isOptimizedBuildSupportEnabled_{false}
+		, isHideDebuggerModeEnabled_{false}
 	{
 		if (startInfo)
 			optionalStartInfo_ = *startInfo;
@@ -136,6 +137,18 @@ namespace CppCoverage
 	}
 
 	//-------------------------------------------------------------------------
+	void Options::EnableHideDebuggerMode()
+	{
+		isHideDebuggerModeEnabled_ = true;
+	}
+
+	//-------------------------------------------------------------------------
+	bool Options::IsHideDebuggerModeEnabled() const
+	{
+		return isHideDebuggerModeEnabled_;
+	}
+
+	//-------------------------------------------------------------------------
 	void Options::AddExport(const OptionsExport& optionExport)
 	{
 		exports_.push_back(optionExport);
@@ -219,6 +232,7 @@ namespace CppCoverage
 		ostr << L"Aggregate by file: " << options.isAggregateByFileModeEnabled_ << std::endl;
 		ostr << L"Continue after C++ exception: " << options.isContinueAfterCppExceptionModeEnabled_ << std::endl;
 		ostr << L"Optimized build support: " << options.isOptimizedBuildSupportEnabled_ << std::endl;
+		ostr << L"Hide debugger: " << options.isHideDebuggerModeEnabled_ << std::endl;
 
 		ostr << L"Export: ";
 		for (const auto& optionExport : options.exports_)

--- a/CppCoverage/Options.hpp
+++ b/CppCoverage/Options.hpp
@@ -67,6 +67,9 @@ namespace CppCoverage
 		void EnableContinueAfterCppExceptionMode();
 		bool IsContinueAfterCppExceptionModeEnabled() const;
 
+		void EnableHideDebuggerMode();
+		bool IsHideDebuggerModeEnabled() const;
+
 		void AddExport(const OptionsExport&);
 		const std::vector<OptionsExport>& GetExports() const;
 		
@@ -102,6 +105,7 @@ namespace CppCoverage
 		bool isAggregateByFileModeEnabled_;
 		bool isContinueAfterCppExceptionModeEnabled_;
 		bool isOptimizedBuildSupportEnabled_;
+		bool isHideDebuggerModeEnabled_;
 		std::vector<OptionsExport> exports_;
 		std::vector<boost::filesystem::path> inputCoveragePaths_;
 		std::vector<UnifiedDiffSettings> unifiedDiffSettingsCollection_;

--- a/CppCoverage/OptionsParser.cpp
+++ b/CppCoverage/OptionsParser.cpp
@@ -476,6 +476,8 @@ namespace CppCoverage
 			options.EnableContinueAfterCppExceptionMode();
 		if (IsOptionSelected(variables, ProgramOptions::OptimizedBuildOption))
 			options.EnableOptimizedBuildSupport();
+		if (IsOptionSelected(variables, ProgramOptions::HideDebuggerOption))
+			options.EnableHideDebuggerMode();
 
 		AddExporTypes(variables, options);
 		AddInputCoverages(variables, options);

--- a/CppCoverage/ProgramOptions.cpp
+++ b/CppCoverage/ProgramOptions.cpp
@@ -105,7 +105,8 @@ namespace CppCoverage
 					"Exclude all lines match the regular expression. Regular expression must match the whole line.")
 				(ProgramOptions::SubstitutePdbSourcePathOption.c_str(), po::value<T_Strings>()->composing(),
 					"Substitute the starting path defined in the pdb by a local path.\nFormat: <pdbStartPath>?<localPath>. " 
-					"Can have multiple occurrences.");
+					"Can have multiple occurrences.")
+				(ProgramOptions::HideDebuggerOption.c_str(), "Hide debugger from the process.");
 		}
 
 		//-------------------------------------------------------------------------
@@ -146,6 +147,7 @@ namespace CppCoverage
 	const std::string ProgramOptions::OptimizedBuildOption = "optimized_build";
 	const std::string ProgramOptions::ExcludedLineRegexOption = "excluded_line_regex";
 	const std::string ProgramOptions::SubstitutePdbSourcePathOption = "substitute_pdb_source_path";
+	const std::string ProgramOptions::HideDebuggerOption = "hide_debugger";
 
 	//-------------------------------------------------------------------------
 	ProgramOptions::ProgramOptions()

--- a/CppCoverage/ProgramOptions.hpp
+++ b/CppCoverage/ProgramOptions.hpp
@@ -52,6 +52,7 @@ namespace CppCoverage
 		static const std::string OptimizedBuildOption;
 		static const std::string ExcludedLineRegexOption;
 		static const std::string SubstitutePdbSourcePathOption;
+		static const std::string HideDebuggerOption;
 
 		ProgramOptions();
 

--- a/CppCoverage/RunCoverageSettings.cpp
+++ b/CppCoverage/RunCoverageSettings.cpp
@@ -34,7 +34,8 @@ namespace CppCoverage
 	      maxUnmatchPathsForWarning_{0},
 	      optimizedBuildSupport_{false},
 	      excludedLineRegexes_{excludedLineRegexes},
-	      substitutePdbSourcePath_{substitutePdbSourcePath}
+	      substitutePdbSourcePath_{substitutePdbSourcePath},
+		  hideDebugger_{false}
 	{
 	}
 
@@ -60,6 +61,12 @@ namespace CppCoverage
 	void RunCoverageSettings::SetOptimizedBuildSupport(bool optimizedBuildSupport)
 	{
 		optimizedBuildSupport_ = optimizedBuildSupport;
+	}
+
+	//-------------------------------------------------------------------------
+	void RunCoverageSettings::SetHideDebugger(bool hideDebugger)
+	{
+		hideDebugger_ = hideDebugger;
 	}
 
 	//-------------------------------------------------------------------------
@@ -114,5 +121,11 @@ namespace CppCoverage
 	const std::vector<SubstitutePdbSourcePath>& RunCoverageSettings::GetSubstitutePdbSourcePaths() const
 	{
 		return substitutePdbSourcePath_;
+	}
+
+	//-------------------------------------------------------------------------
+	bool RunCoverageSettings::GetHideDebugger() const
+	{
+		return hideDebugger_;
 	}
 }

--- a/CppCoverage/RunCoverageSettings.hpp
+++ b/CppCoverage/RunCoverageSettings.hpp
@@ -43,6 +43,7 @@ namespace CppCoverage
 		void SetContinueAfterCppException(bool);
 		void SetMaxUnmatchPathsForWarning(size_t);
 		void SetOptimizedBuildSupport(bool);
+		void SetHideDebugger(bool);
 
 		const StartInfo& GetStartInfo() const;
 		const CoverageFilterSettings& GetCoverageFilterSettings() const;
@@ -53,6 +54,7 @@ namespace CppCoverage
 		bool GetOptimizedBuildSupport() const;
 		const std::vector<std::wstring>& GetExcludedLineRegexes() const;
 		const std::vector<SubstitutePdbSourcePath>& GetSubstitutePdbSourcePaths() const;
+		bool GetHideDebugger() const;
 
 	private:
 		StartInfo startInfo_;
@@ -64,5 +66,6 @@ namespace CppCoverage
 		bool optimizedBuildSupport_;
 		std::vector<std::wstring> excludedLineRegexes_;
 		std::vector<SubstitutePdbSourcePath> substitutePdbSourcePath_;
+		bool hideDebugger_;
 	};
 }

--- a/CppCoverageTest/CppCoverageTest.vcxproj
+++ b/CppCoverageTest/CppCoverageTest.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{4360D299-2F7D-462E-B7EF-0670FD06F478}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>CppCoverageTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/CppCoverageTest/OptionsParserTest.cpp
+++ b/CppCoverageTest/OptionsParserTest.cpp
@@ -50,6 +50,7 @@ namespace CppCoverageTest
 		ASSERT_FALSE(options->IsOptimizedBuildSupportEnabled());
 		ASSERT_TRUE(options->GetExcludedLineRegexes().empty());
 		ASSERT_TRUE(options->GetSubstitutePdbSourcePaths().empty());
+		ASSERT_FALSE(options->IsHideDebuggerModeEnabled());
 	}
 
 	//-------------------------------------------------------------------------
@@ -123,6 +124,15 @@ namespace CppCoverageTest
 		ASSERT_TRUE(TestTools::Parse(parser,
 		{ TestTools::GetOptionPrefix() + cov::ProgramOptions::ContinueAfterCppExceptionOption })
 			->IsContinueAfterCppExceptionModeEnabled());
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(OptionsParserTest, HideDebugger)
+	{
+		cov::OptionsParser parser;
+
+		ASSERT_TRUE(TestTools::Parse(parser,
+			{ TestTools::GetOptionPrefix() + cov::ProgramOptions::HideDebuggerOption })->IsHideDebuggerModeEnabled());
 	}
 
 	//-------------------------------------------------------------------------

--- a/CppCoverageTest/TestTools.cpp
+++ b/CppCoverageTest/TestTools.cpp
@@ -149,6 +149,7 @@ namespace CppCoverageTest
 			settings.SetCoverChildren(args.coverChildren_);
 			settings.SetContinueAfterCppException(args.continueAfterCppException_);
 			settings.SetOptimizedBuildSupport(args.optimizedBuildSupport_);
+			settings.SetHideDebugger(args.hideDebugger_);
 
 			auto coverageData = codeCoverageRunner.RunCoverage(settings);
 

--- a/CppCoverageTest/TestTools.hpp
+++ b/CppCoverageTest/TestTools.hpp
@@ -73,6 +73,7 @@ namespace CppCoverageTest
 			bool optimizedBuildSupport_ = false;
 			std::vector<std::wstring> excludedLineRegexes_;
 			std::vector<CppCoverage::SubstitutePdbSourcePath> substitutePdbSourcePath_;
+			bool hideDebugger_ = false;
 		};
 
 		//---------------------------------------------------------------------

--- a/Exporter/Exporter.vcxproj
+++ b/Exporter/Exporter.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{865B72E7-DA46-4392-A1B3-E5BD752C7041}</ProjectGuid>
     <RootNamespace>Exporter</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ExporterTest/ExporterTest.vcxproj
+++ b/ExporterTest/ExporterTest.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{A8BDB699-992D-4583-84B4-00CA8CFC1C06}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ExporterTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/FileFilter/FileFilter.vcxproj
+++ b/FileFilter/FileFilter.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{6FD7C5BE-04BD-496D-A924-285A3E867814}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>FileFilter</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/FileFilterTest/FileFilterTest.vcxproj
+++ b/FileFilterTest/FileFilterTest.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{94E71104-2BAB-420B-8B69-833708CA6D35}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>FileFilterTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/OpenCppCoverage/OpenCppCoverage.cpp
+++ b/OpenCppCoverage/OpenCppCoverage.cpp
@@ -151,6 +151,7 @@ namespace OpenCppCoverage
 				runCoverageSettings.SetContinueAfterCppException(options.IsContinueAfterCppExceptionModeEnabled());
 				runCoverageSettings.SetMaxUnmatchPathsForWarning(maxUnmatchPathsForWarning);
 				runCoverageSettings.SetOptimizedBuildSupport(options.IsOptimizedBuildSupportEnabled());
+				runCoverageSettings.SetHideDebugger(options.IsHideDebuggerModeEnabled());
 				auto coverageData = codeCoverageRunner.RunCoverage(runCoverageSettings);
 				exitCode = coverageData.GetExitCode();
 				coveraDatas.push_back(std::move(coverageData));

--- a/OpenCppCoverage/OpenCppCoverage.vcxproj
+++ b/OpenCppCoverage/OpenCppCoverage.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{3A493CE5-D6BE-4DA5-BC53-78A8F6481E03}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>OpenCppCoverage</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/OpenCppCoverageTest/OpenCppCoverageTest.vcxproj
+++ b/OpenCppCoverageTest/OpenCppCoverageTest.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{F892B2B1-64A9-4809-BA9C-24A1F2E82979}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>OpenCppCoverage</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/TestCoverageConsole/TestCoverageConsole.vcxproj
+++ b/TestCoverageConsole/TestCoverageConsole.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{0DD16EDF-BD43-4D7B-B357-931F48F2FCC6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>TestCoverageConsole</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/TestCoverageOptimizedBuild/TestCoverageOptimizedBuild.vcxproj
+++ b/TestCoverageOptimizedBuild/TestCoverageOptimizedBuild.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{2FD17BA1-0E02-49E6-84C3-0A8F63FEF871}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>TestCoverageOptimizedBuild</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <ProjectName>TestCoverageOptimizedBuild</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/TestCoverageSharedLib/TestCoverageSharedLib.vcxproj
+++ b/TestCoverageSharedLib/TestCoverageSharedLib.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{0481B51C-98F1-4E92-A51E-162B77ECD939}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>TestCoverageSharedLib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/TestCppCli/TestCppCli.vcxproj
+++ b/TestCppCli/TestCppCli.vcxproj
@@ -25,6 +25,7 @@
     <ProjectGuid>{21A0DD74-91CB-485A-BACD-A18047E076D8}</ProjectGuid>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>TestCppCli</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/TestHelper/TestHelper.vcxproj
+++ b/TestHelper/TestHelper.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{120D7BDF-3B21-48B7-8EB7-DAD94F863026}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>TestHelper</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Tools/Tools.vcxproj
+++ b/Tools/Tools.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{7F6D05EF-DEB0-4C64-BD13-A85F46314B91}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Tools</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ToolsTest/ToolsTest.vcxproj
+++ b/ToolsTest/ToolsTest.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{42F32EB3-42B6-498A-9823-26E6E5982EE3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ToolsTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
This is a change I'm using to improve performance while getting coverage. When a debugger is attached to a process Windows will enable heap tracing for the process, which completely tanks performance. There are also some other things that behave differently if `IsDebuggerPresent` returns 1.

Probably it is not ready to be merged yet, but I can do some extra work (like an additional command line parameter) if there is interest.