### PR TITLE
Fixed html doctype declarations

### DIFF
--- a/Exporter/Html/Template/MainTemplate.html
+++ b/Exporter/Html/Template/MainTemplate.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <meta charset="utf-8"/>

--- a/Exporter/Html/Template/SourceTemplate.html
+++ b/Exporter/Html/Template/SourceTemplate.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
         <meta charset="utf-8"/>


### PR DESCRIPTION
When trying to load the generated html as an xml file I get the following error:

> System.Xml.XmlException: 'doctype' is an unexpected token. The expected token is 'DOCTYPE'. Line 1, position 3.