### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,16 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+  strategy:
+      matrix:
+        os: [windows-latest, windows-2016]
+    
+    steps:
+    - uses: actions/checkout@v2
+    name:  BuildThirdPartyDependencies
+      BuildThirdPartyDependencies.bat
+    name: Build
+      cd “C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\”
+      .\MSBuild.exe CppCoverage.sln
+  

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,16 +1,21 @@
 name: CI
+
 on: [push, pull_request]
+
 jobs:
   build:
   strategy:
-      matrix:
+     matrix:
         os: [windows-latest, windows-2016]
-    
-    steps:
+
+  runs-on: ${{ matrix.os }}    
+
+  steps:
     - uses: actions/checkout@v2
     name:  BuildThirdPartyDependencies
+    run: |
       BuildThirdPartyDependencies.bat
     name: Build
+    run: |
       cd “C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\”
       .\MSBuild.exe CppCoverage.sln
-  

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,18 +4,18 @@ on: [push, pull_request]
 
 jobs:
   build:
-  strategy:
-     matrix:
+    strategy:
+      matrix:
         os: [windows-latest, windows-2016]
 
-  runs-on: ${{ matrix.os }}    
+    runs-on: ${{ matrix.os }}    
 
-  steps:
-    - uses: actions/checkout@v2
-    - name:  BuildThirdPartyDependencies
-      run: |
-        BuildThirdPartyDependencies.bat
-    - name: Build
-      run: |
-        cd “C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\”
-        .\MSBuild.exe CppCoverage.sln
+    steps:
+      - uses: actions/checkout@v2
+      - name:  BuildThirdPartyDependencies
+        run: |
+          BuildThirdPartyDependencies.bat
+      - name: Build
+        run: |
+          cd “C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\”
+          .\MSBuild.exe CppCoverage.sln

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - name:  BuildThirdPartyDependencies
         run: |
-          BuildThirdPartyDependencies.bat
+          .\BuildThirdPartyDependencies.bat
       - name: Build
         run: |
           cd “C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\”

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,10 +12,10 @@ jobs:
 
   steps:
     - uses: actions/checkout@v2
-    name:  BuildThirdPartyDependencies
-    run: |
-      BuildThirdPartyDependencies.bat
-    name: Build
-    run: |
-      cd “C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\”
-      .\MSBuild.exe CppCoverage.sln
+    - name:  BuildThirdPartyDependencies
+      run: |
+        BuildThirdPartyDependencies.bat
+    - name: Build
+      run: |
+        cd “C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\”
+        .\MSBuild.exe CppCoverage.sln


### PR DESCRIPTION
@OpenCppCoverage  Any idea what it fails to build?
BuildThirdPartyDependencies.bat failed, see https://github.com/amai2012/OpenCppCoverage/runs/477002681?check_suite_focus=true