### PR TITLE
Fix empty coverage report for code from network drives

### DIFF
--- a/CppCoverage/HandleInformation.cpp
+++ b/CppCoverage/HandleInformation.cpp
@@ -73,7 +73,7 @@ namespace CppCoverage
 			}
 
 			// Handle network drive. We just remove prefix.
-			queryDosDevicesMapping.emplace_back(L"\\Device\\Mup", L"");
+			queryDosDevicesMapping.emplace_back(L"\\Device\\Mup", L"\\");
 			return queryDosDevicesMapping;
 		}
 


### PR DESCRIPTION
In GetQueryDosDevicesMapping the prefix is removed for network drives.
This results in invalid paths, and only an empty coverage report is
generated. This fix replaces the prefix with "\\" for network drives,
so that network paths remain valid.
Example: "\\Device\\Mup\\share\\x" -> "\\\\share\\x" and not the
invalid path "\\share\\x".

