### PR TITLE
set default locale explicitly for html exporter

### DIFF
--- a/Exporter/Html/HtmlFileCoverageExporter.cpp
+++ b/Exporter/Html/HtmlFileCoverageExporter.cpp
@@ -114,6 +114,7 @@ namespace Exporter
 		std::wifstream ifs{filePath.string()};
 		if (!ifs)
 			THROW(L"Cannot open file : " + filePath.wstring());
+		ifs.imbue(std::locale("", LC_CTYPE));
 
 		std::wstring line;
 		const Plugin::LineCoverage* previousLineCoverage = nullptr;


### PR DESCRIPTION
This one line fixed my garbled shift-jis chars on my shift-jis encoding os (it means source files are using the Windows default encoding; they are garbled without this fix).