### PR TITLE
Shared modules are counted multiple times when calculating overall coverage rate

### DIFF
--- a/CppCoverage/CoverageRateComputer.cpp
+++ b/CppCoverage/CoverageRateComputer.cpp
@@ -75,6 +75,8 @@ namespace CppCoverage
 	//-------------------------------------------------------------------------
 	void CoverageRateComputer::ComputeCoverageRateCache(const Plugin::CoverageData& coverageData)
 	{
+		std::vector<std::wstring > computedFiles;
+
 		for (const auto& module : coverageData.GetModules())
 		{
 			CoverageRate moduleCoverageRate;
@@ -85,11 +87,20 @@ namespace CppCoverage
 
 				moduleCoverageRate += fileCoverageRate;
 				fileCoverageRate_.emplace(file.get(), fileCoverageRate);
+
+				std::wstring currentfile = file->GetPath().wstring();
+				if (std::find(computedFiles.begin(), computedFiles.end(), currentfile) == computedFiles.end())
+				{
+					coverageRate_ += fileCoverageRate;
+					computedFiles.push_back(currentfile);
+				}
 			}
 
 			moduleCoverageRate_.emplace(module.get(), moduleCoverageRate);
-			coverageRate_ += moduleCoverageRate;
 		}
+
+		computedFiles.clear();
+		computedFiles.shrink_to_fit();
 	}
 	
 	//-------------------------------------------------------------------------


### PR DESCRIPTION
Shared modules are counted multiple times when calculating overall coverage rate.