### PR TITLE
Feature: Source level coverage

### DIFF
--- a/CppCoverage/CodeCoverageRunner.cpp
+++ b/CppCoverage/CodeCoverageRunner.cpp
@@ -22,6 +22,7 @@
 
 #include "tools/Log.hpp"
 
+#include "CoverageLevel.hpp"
 #include "Plugin/Exporter/CoverageData.hpp"
 #include "Debugger.hpp"
 #include "ExecutedAddressManager.hpp"
@@ -69,7 +70,8 @@ namespace CppCoverage
 			settings.GetCoverageFilterSettings(),
 			settings.GetUnifiedDiffSettings(), 
 			settings.GetExcludedLineRegexes(),
-			settings.GetOptimizedBuildSupport());
+			settings.GetOptimizedBuildSupport(),
+			settings.GetCoverageLevel());
 
 		monitoredLineRegister_ = std::make_unique<MonitoredLineRegister>(
 		    breakpoint_,

--- a/CppCoverage/CoverageFilterManager.cpp
+++ b/CppCoverage/CoverageFilterManager.cpp
@@ -18,6 +18,8 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include "CppCoverageException.hpp"
+#include "CoverageLevel.hpp"
 #include "CoverageFilterManager.hpp"
 #include "UnifiedDiffCoverageFilterManager.hpp"
 
@@ -29,16 +31,20 @@ namespace CppCoverage
 {
 	//-------------------------------------------------------------------------
 	CoverageFilterManager::CoverageFilterManager(
-		const CoverageFilterSettings& settings,
+		const CoverageFilterSettings& settings,	
 		const std::vector<UnifiedDiffSettings>& unifiedDiffSettingsCollection,
 		const std::vector<std::wstring>& excludedLineRegexes,
-		bool useReleaseCoverageFilter)
+		bool useReleaseCoverageFilter,
+		CoverageLevel coverageLevel)
 		: wildcardCoverageFilter_{ settings }
 		, unifiedDiffCoverageFilterManager_{ unifiedDiffSettingsCollection }
 		, lineFilter_{ excludedLineRegexes }
 		, optionalReleaseCoverageFilter_{ useReleaseCoverageFilter ?
-			std::make_unique<FileFilter::ReleaseCoverageFilter>() : nullptr }		
+			std::make_unique<FileFilter::ReleaseCoverageFilter>() : nullptr }
+		, coverageLevel_{ coverageLevel }
 	{
+		if (coverageLevel != CoverageLevel::Line && coverageLevel != CoverageLevel::Source)
+			THROW("Invalid coverage level");
 	}
 
 	//-------------------------------------------------------------------------
@@ -57,6 +63,12 @@ namespace CppCoverage
 			return false;
 
 		return unifiedDiffCoverageFilterManager_.IsSourceFileSelected(filename);
+	}
+
+	//-------------------------------------------------------------------------
+	CoverageLevel CoverageFilterManager::GetCoverageLevel() const
+	{
+		return coverageLevel_;
 	}
 
 	//-------------------------------------------------------------------------

--- a/CppCoverage/CoverageFilterManager.hpp
+++ b/CppCoverage/CoverageFilterManager.hpp
@@ -33,6 +33,7 @@ namespace CppCoverage
 {
 	class CoverageFilterSettings;
 	class UnifiedDiffSettings;
+	enum class Coveragelevel;
 
 	class CPPCOVERAGE_DLL CoverageFilterManager: public ICoverageFilterManager
 	{
@@ -41,12 +42,14 @@ namespace CppCoverage
 			const CoverageFilterSettings&,
 			const std::vector<UnifiedDiffSettings>&,
 			const std::vector<std::wstring>& excludedLineRegexes,
-			bool useReleaseCoverageFilter);
+			bool useReleaseCoverageFilter,
+			CoverageLevel coverageLevel);
 
 		~CoverageFilterManager();
 
 		bool IsModuleSelected(const std::wstring& filename) const override;
 		bool IsSourceFileSelected(const std::wstring& filename) override;
+		CoverageLevel GetCoverageLevel() const override;
 		bool IsLineSelected(
 			const FileFilter::ModuleInfo&,
 			const FileFilter::FileInfo&,
@@ -63,5 +66,6 @@ namespace CppCoverage
 		FileFilter::LineFilter lineFilter_;
 
 		const std::unique_ptr<FileFilter::ReleaseCoverageFilter> optionalReleaseCoverageFilter_;
+		const CoverageLevel coverageLevel_;
 	};
 }

--- a/CppCoverage/CoverageLevel.hpp
+++ b/CppCoverage/CoverageLevel.hpp
@@ -1,5 +1,5 @@
 // OpenCppCoverage is an open source code coverage for C++.
-// Copyright (C) 2016 OpenCppCoverage
+// Copyright (C) 2014 OpenCppCoverage
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -16,34 +16,11 @@
 
 #pragma once
 
-#include "CppCoverageExport.hpp"
-#include <string>
-
-namespace FileFilter
-{
-	class ModuleInfo;
-	class FileInfo;
-	class LineInfo;
-}
-
 namespace CppCoverage
 {
-	class CoverageFilterSettings;
-	enum class CoverageLevel;
-
-	class CPPCOVERAGE_DLL ICoverageFilterManager
+	enum class CoverageLevel
 	{
-	public:
-		virtual ~ICoverageFilterManager() = default;
-
-		virtual bool IsModuleSelected(const std::wstring& filename) const = 0;
-		virtual bool IsSourceFileSelected(const std::wstring& filename) = 0;
-		virtual CoverageLevel GetCoverageLevel() const = 0;
-		virtual bool IsLineSelected(
-			const FileFilter::ModuleInfo&,
-			const FileFilter::FileInfo&,
-			const FileFilter::LineInfo&) = 0;
+		Line,
+		Source
 	};
 }
-
-

--- a/CppCoverage/CppCoverage.vcxproj
+++ b/CppCoverage/CppCoverage.vcxproj
@@ -168,6 +168,7 @@
     <ClInclude Include="CodeCoverageRunner.hpp" />
     <ClInclude Include="CoverageDataMerger.hpp" />
     <ClInclude Include="CoverageFilterManager.hpp" />
+    <ClInclude Include="CoverageLevel.hpp" />
     <ClInclude Include="DebugInformationEnumerator.hpp" />
     <ClInclude Include="ExportOptionParser.hpp" />
     <ClInclude Include="ExportPluginDescription.hpp" />

--- a/CppCoverage/DebugInformationEnumerator.hpp
+++ b/CppCoverage/DebugInformationEnumerator.hpp
@@ -61,8 +61,10 @@ namespace CppCoverage
 	{
 	  public:
 		explicit DebugInformationEnumerator(const std::vector<SubstitutePdbSourcePath>&);
-		bool Enumerate(const std::filesystem::path&,
-		               IDebugInformationHandler&);
+		bool 
+		EnumerateSourceLevel(const std::filesystem::path&, IDebugInformationHandler&, std::vector<std::filesystem::path>&);
+		bool 
+		EnumerateLineLevel(const std::filesystem::path&, IDebugInformationHandler&);
 
 	  private:
 		void

--- a/CppCoverage/ExecutedAddressManager.cpp
+++ b/CppCoverage/ExecutedAddressManager.cpp
@@ -74,6 +74,26 @@ namespace CppCoverage
 	}
 
 	//-------------------------------------------------------------------------
+	void ExecutedAddressManager::AddModuleFiles(const std::wstring& moduleName, const std::vector<std::filesystem::path>& filepaths)
+	{
+		auto module = modules_.find(moduleName);
+
+		if(module == modules_.end())
+			THROW("Cannot find module.");
+
+		auto& files = module->second.files_;
+		for (const auto& filepath : filepaths)
+		{
+			auto file = files.find(filepath.wstring());
+			
+			if (file == files.end())
+			{
+				files.emplace(filepath.wstring(), File{});
+			}
+		}
+	}
+
+	//-------------------------------------------------------------------------
 	void ExecutedAddressManager::AddModule(
 		const std::wstring& moduleName,
 		void* dllBaseOfImage)

--- a/CppCoverage/ExecutedAddressManager.hpp
+++ b/CppCoverage/ExecutedAddressManager.hpp
@@ -38,6 +38,7 @@ namespace CppCoverage
 		~ExecutedAddressManager();
 
 		void AddModule(const std::wstring& moduleName, void* dllBaseOfImage);
+		void AddModuleFiles(const std::wstring& moduleName, const std::vector<std::filesystem::path>& filepaths);
 		void OnUnloadModule(HANDLE hProcess, void* dllBaseOfImage);
 
 		bool RegisterAddress(

--- a/CppCoverage/MonitoredLineRegister.cpp
+++ b/CppCoverage/MonitoredLineRegister.cpp
@@ -17,7 +17,7 @@
 #include "stdafx.h"
 
 #include "MonitoredLineRegister.hpp"
-
+#include "CoverageLevel.hpp"
 #include "ICoverageFilterManager.hpp"
 #include "Address.hpp"
 #include "BreakPoint.hpp"
@@ -117,7 +117,20 @@ namespace CppCoverage
 		moduleInfo_ = std::make_unique<FileFilter::ModuleInfo>(
 		    hProcess, modulePath, baseOfImage);
 
-		return debugInformationEnumerator_->Enumerate(modulePath, *this);
+		if (coverageFilterManager_->GetCoverageLevel() == CoverageLevel::Line)
+		{
+			return debugInformationEnumerator_->EnumerateLineLevel(modulePath, *this);
+		}
+		else
+		{
+			std::vector<std::filesystem::path> filepaths;
+			bool result = debugInformationEnumerator_->EnumerateSourceLevel(modulePath, *this, filepaths);
+			
+			if (result)
+				executedAddressManager_->AddModuleFiles(modulePath, filepaths);
+
+			return result;
+		}
 	}
 
 	//--------------------------------------------------------------------------

--- a/CppCoverage/Options.cpp
+++ b/CppCoverage/Options.cpp
@@ -147,6 +147,18 @@ namespace CppCoverage
       return isStopOnAssertModeEnabled_;
     }
 
+	//-------------------------------------------------------------------------
+    void Options::SetCoverageLevel(CoverageLevel coverageLevel)
+    {
+      coverageLevel_ = coverageLevel;
+    }
+    
+    //-------------------------------------------------------------------------
+	CoverageLevel Options::GetCoverageLevel() const
+    {
+      return coverageLevel_;
+    }
+
     //-------------------------------------------------------------------------
 	void Options::AddExport(OptionsExport&& optionExport)
 	{

--- a/CppCoverage/Options.hpp
+++ b/CppCoverage/Options.hpp
@@ -29,7 +29,8 @@
 namespace CppCoverage
 {
 	class Patterns;	
-	
+	enum class CoverageLevel;
+
 	enum class LogLevel
 	{
 		Quiet,
@@ -54,6 +55,9 @@ namespace CppCoverage
 
 		void SetLogLevel(LogLevel);
 		LogLevel GetLogLevel() const;
+
+		void SetCoverageLevel(CoverageLevel);
+		CoverageLevel GetCoverageLevel() const;
 		
 		void EnablePlugingMode();
 		bool IsPlugingModeEnabled() const;
@@ -100,6 +104,7 @@ namespace CppCoverage
 		boost::optional<StartInfo> optionalStartInfo_;
 
 		LogLevel logLevel_;
+		CoverageLevel coverageLevel_;
 		bool isPluginModeEnabled_;
 		bool isCoverChildrenModeEnabled_;
 		bool isAggregateByFileModeEnabled_;

--- a/CppCoverage/OptionsParser.cpp
+++ b/CppCoverage/OptionsParser.cpp
@@ -30,6 +30,7 @@
 #include "CppCoverage/Patterns.hpp"
 
 #include "Options.hpp"
+#include "CoverageLevel.hpp"
 #include "CppCoverageException.hpp"
 #include "ProgramOptions.hpp"
 #include "OptionsExport.hpp"
@@ -184,14 +185,36 @@ namespace CppCoverage
 
 		//----------------------------------------------------------------------------
 		std::pair<fs::path, boost::optional<fs::path>>
-		ExtractUnifiedDiffOption(const std::string& option)
+			ExtractUnifiedDiffOption(const std::string& option)
 		{
 			auto pos = option.find(OptionsParser::PathSeparator);
 
 			if (pos == std::string::npos)
-				return {option, boost::none};
+				return { option, boost::none };
 
-			return {option.substr(0, pos), fs::path{option.substr(pos + 1)}};
+			return { option.substr(0, pos), fs::path{option.substr(pos + 1)} };
+		}
+
+		//----------------------------------------------------------------------------
+		void
+			AddCoverageLevel(const ProgramOptionsVariablesMap& variablesMap,
+				Options& options)
+		{
+			if (variablesMap.IsOptionSelected(ProgramOptions::CoverageLevelOption))
+			{
+				auto coverageLevelStr = variablesMap.GetValue<std::string>(
+					ProgramOptions::CoverageLevelOption)
+					;
+
+				if (coverageLevelStr == ProgramOptions::CoverageLevelLineValue)
+				{
+					options.SetCoverageLevel(CoverageLevel::Line);
+				}
+				else if (coverageLevelStr == ProgramOptions::CoverageLevelSourceValue)
+				{
+					options.SetCoverageLevel(CoverageLevel::Source);
+				}
+			}
 		}
 
 		//----------------------------------------------------------------------------
@@ -448,6 +471,7 @@ namespace CppCoverage
 		if (variablesMap.IsOptionSelected(ProgramOptions::StopOnAssertOption))
 			options.EnableStopOnAssertMode();
 
+		AddCoverageLevel(variablesMap, options);
 		AddInputCoverages(variablesMap, options);
 		AddUnifiedDiff(variablesMap, options);
 		AddExcludedLineRegexes(variablesMap, options);

--- a/CppCoverage/ProgramOptions.cpp
+++ b/CppCoverage/ProgramOptions.cpp
@@ -54,6 +54,15 @@ namespace CppCoverage
 		}
 
 		//---------------------------------------------------------------------
+		std::string GetCoverageTypeHelp()
+		{
+			return std::string("Format: <coverageLevel>.\n") + 
+				"<coverageLevel> can be: \n" + 
+				"   line: line level coverage\n" +
+				"   source : source level coverage";
+		}
+
+		//---------------------------------------------------------------------
 		void
 		FillConfigurationOptions(po::options_description& options,
 			const std::vector<std::unique_ptr<IOptionParser>>& optionParsers)
@@ -79,8 +88,11 @@ namespace CppCoverage
 				(ProgramOptions::WorkingDirectoryOption.c_str(), po::value<std::string>(), "The program working directory.")
 				(ProgramOptions::CoverChildrenOption.c_str(), "Enable code coverage for children processes.")
 				(ProgramOptions::NoAggregateByFileOption.c_str(), "Do not aggregate coverage for same file path.")
-                (ProgramOptions::StopOnAssertOption.c_str(), "Do not continue after DebugBreak() or assert().")
-              (ProgramOptions::UnifiedDiffOption.c_str(),
+				(ProgramOptions::StopOnAssertOption.c_str(), "Do not continue after DebugBreak() or assert().")
+				(ProgramOptions::CoverageLevelOption.c_str(),
+				po::value<std::string>()->default_value({ ProgramOptions::CoverageLevelLineValue }, ProgramOptions::CoverageLevelLineValue)->composing(),
+				GetCoverageTypeHelp().c_str())
+                (ProgramOptions::UnifiedDiffOption.c_str(),
 					po::value<T_Strings>()->composing(), GetUnifiedDiffHelp().c_str())
 				(ProgramOptions::ContinueAfterCppExceptionOption.c_str(), "Try to continue after throwing a C++ exception.")
 				(ProgramOptions::OptimizedBuildOption.c_str(), 
@@ -105,6 +117,9 @@ namespace CppCoverage
 	}
 
 	//-------------------------------------------------------------------------
+	const std::string ProgramOptions::CoverageLevelOption = "coverage_level";
+	const std::string ProgramOptions::CoverageLevelSourceValue = "source";
+	const std::string ProgramOptions::CoverageLevelLineValue = "line";
 	const std::string ProgramOptions::SelectedModulesOption = "modules";
 	const std::string ProgramOptions::ExcludedModulesOption = "excluded_modules";
 	const std::string ProgramOptions::SelectedSourcesOption = "sources";

--- a/CppCoverage/ProgramOptions.hpp
+++ b/CppCoverage/ProgramOptions.hpp
@@ -27,6 +27,9 @@ namespace CppCoverage
 	class CPPCOVERAGE_DLL ProgramOptions
 	{
 	public:
+		static const std::string CoverageLevelOption;
+		static const std::string CoverageLevelSourceValue;
+		static const std::string CoverageLevelLineValue;
 		static const std::string SelectedModulesOption;
 		static const std::string ExcludedModulesOption;
 		static const std::string SelectedSourcesOption;

--- a/CppCoverage/RunCoverageSettings.cpp
+++ b/CppCoverage/RunCoverageSettings.cpp
@@ -69,6 +69,12 @@ namespace CppCoverage
 	}
 
 	//-------------------------------------------------------------------------
+	void RunCoverageSettings::SetCoverageLevel(CoverageLevel coverageLevel)
+	{
+		coverageLevel_ = coverageLevel;
+	}
+
+	//-------------------------------------------------------------------------
 	const StartInfo& RunCoverageSettings::GetStartInfo() const
 	{
 		return startInfo_;
@@ -126,5 +132,11 @@ namespace CppCoverage
 	const std::vector<SubstitutePdbSourcePath>& RunCoverageSettings::GetSubstitutePdbSourcePaths() const
 	{
 		return substitutePdbSourcePath_;
+	}
+
+	//-------------------------------------------------------------------------
+	CoverageLevel RunCoverageSettings::GetCoverageLevel() const
+	{
+		return coverageLevel_;
 	}
 }

--- a/CppCoverage/RunCoverageSettings.hpp
+++ b/CppCoverage/RunCoverageSettings.hpp
@@ -26,6 +26,8 @@
 
 namespace CppCoverage
 {
+	enum class CoverageLevel;
+
 	class CPPCOVERAGE_DLL RunCoverageSettings
 	{
 	public:
@@ -44,6 +46,7 @@ namespace CppCoverage
         void SetStopOnAssert(bool);
         void SetMaxUnmatchPathsForWarning(size_t);
 		void SetOptimizedBuildSupport(bool);
+		void SetCoverageLevel(CoverageLevel);
 
 		const StartInfo& GetStartInfo() const;
 		const CoverageFilterSettings& GetCoverageFilterSettings() const;
@@ -55,6 +58,7 @@ namespace CppCoverage
 		bool GetOptimizedBuildSupport() const;
 		const std::vector<std::wstring>& GetExcludedLineRegexes() const;
 		const std::vector<SubstitutePdbSourcePath>& GetSubstitutePdbSourcePaths() const;
+		CoverageLevel GetCoverageLevel() const;
 
 	private:
 		StartInfo startInfo_;
@@ -65,6 +69,7 @@ namespace CppCoverage
         bool stopOnAssert_;
         size_t maxUnmatchPathsForWarning_;
 		bool optimizedBuildSupport_;
+		CoverageLevel coverageLevel_;
 		std::vector<std::wstring> excludedLineRegexes_;
 		std::vector<SubstitutePdbSourcePath> substitutePdbSourcePath_;
 	};

--- a/CppCoverageTest/CppCliTest.cpp
+++ b/CppCoverageTest/CppCliTest.cpp
@@ -20,7 +20,7 @@
 #include "Plugin/Exporter/CoverageData.hpp"
 #include "Plugin/Exporter/ModuleCoverage.hpp"
 #include "TestCoverageSharedLib/TestCoverageSharedLib.hpp"
-
+#include "TestTools.hpp"
 #include "TestHelper/Tools.hpp"
 
 namespace fs = std::filesystem;
@@ -28,7 +28,11 @@ namespace fs = std::filesystem;
 namespace CppCoverageTest
 {
 	//---------------------------------------------------------------------
-	TEST(CppCliTest, ManagedUnManagedModule)
+	class CppCliTest : public TestTools::CoverageLevelTest
+	{};
+
+	//---------------------------------------------------------------------
+	TEST_P(CppCliTest, ManagedUnManagedModule)
 	{
 		auto vsPath = TestHelper::GetVisualStudioPath();
 		fs::path vsConsoleTestPath = vsPath / "Common7" / "IDE" /
@@ -43,10 +47,15 @@ namespace CppCoverageTest
 		    sharedLibModulePath.wstring());
 		coverageArgs.programToRun_ = vsConsoleTestPath;
 
-		auto coverage = TestTools::ComputeCoverageDataPatterns(coverageArgs);
+		auto coverage = TestTools::ComputeCoverageDataPatterns(coverageArgs, this->coverageLevel_);
 		ASSERT_EQ(0, coverage.GetExitCode());
 		const auto& modules = coverage.GetModules();
 		ASSERT_EQ(1, modules.size());
 		ASSERT_EQ(sharedLibModulePath, modules.at(0)->GetPath());
 	}
+
+	INSTANTIATE_TEST_SUITE_P(
+		CppCliTests,
+		CppCliTest,
+		TestTools::CoverageLevelValues);
 }

--- a/CppCoverageTest/DebugInformationEnumeratorTest.cpp
+++ b/CppCoverageTest/DebugInformationEnumeratorTest.cpp
@@ -77,22 +77,47 @@ namespace CppCoverageTest
 	}
 
 	//-------------------------------------------------------------------------
-	TEST(DebugInformationEnumeratorTest, Enumerate)
+	TEST(DebugInformationEnumeratorTest, EnumerateLineLevel)
 	{
 		auto selectedPath =
-		    TestCoverageConsole::GetDebugInformationEnumeratorTestPath();
+			TestCoverageConsole::GetDebugInformationEnumeratorTestPath();
 		DebugInformationHandlerMock debugInformationHandler{
-		    selectedPath.filename()};
+			selectedPath.filename() };
 
 		CppCoverage::DebugInformationEnumerator debugInformationEnumerator{ {} };
 
 		auto binary = TestCoverageConsole::GetOutputBinaryPath();
-		ASSERT_TRUE(debugInformationEnumerator.Enumerate(
-		    binary, debugInformationHandler));
+		ASSERT_TRUE(debugInformationEnumerator.EnumerateLineLevel(
+			binary, debugInformationHandler));
 
 		auto lineWithDebugInfo = GetLineNumbersWithTag(
-		    debugInformationHandler.selectedFullPath_, L"@DebugInfoExpected");
+			debugInformationHandler.selectedFullPath_, L"@DebugInfoExpected");
 
+		ASSERT_EQ(debugInformationHandler.lines_, lineWithDebugInfo);
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(DebugInformationEnumeratorTest, EnumerateSourceLevel)
+	{
+		const std::vector<std::wstring> expectedSources = {};
+		auto selectedPath =
+			TestCoverageConsole::GetDebugInformationEnumeratorTestPath();
+		DebugInformationHandlerMock debugInformationHandler{
+			selectedPath.filename() };
+
+		CppCoverage::DebugInformationEnumerator debugInformationEnumerator{ {} };
+
+		auto binary = TestCoverageConsole::GetOutputBinaryPath();
+		std::vector<std::filesystem::path> filepaths;
+		ASSERT_TRUE(debugInformationEnumerator.EnumerateSourceLevel(
+			binary, debugInformationHandler, filepaths));
+
+		auto lineWithDebugInfo = GetLineNumbersWithTag(
+			debugInformationHandler.selectedFullPath_, L"@DebugInfoExpected");
+
+		ASSERT_EQ(1, filepaths.size());
+		ASSERT_EQ(debugInformationHandler.selectedFilename_, filepaths.at(0).filename().wstring());
+		ASSERT_EQ(0, lineWithDebugInfo.size());
 		ASSERT_EQ(debugInformationHandler.lines_, lineWithDebugInfo);
 	}
 }

--- a/CppCoverageTest/OptionsParserTest.cpp
+++ b/CppCoverageTest/OptionsParserTest.cpp
@@ -17,6 +17,7 @@
 #include "stdafx.h"
 
 #include <filesystem>
+#include "CppCoverage/CoverageLevel.hpp"
 #include "CppCoverage/Options.hpp"
 #include "CppCoverage/ProgramOptions.hpp"
 
@@ -32,7 +33,18 @@ namespace CppCoverageTest
 {
 	namespace
 	{
-		const std::string optionShortPrefix = "-";		
+		const std::string optionShortPrefix = "-";	
+
+		std::vector<std::string> BuildCoverageLevelOption(cov::CoverageLevel coverageLevel, const std::string& prefix)
+		{
+			std::vector<std::string> options;
+			options.emplace_back(prefix + cov::ProgramOptions::CoverageLevelOption);
+			options.emplace_back((coverageLevel == cov::CoverageLevel::Line ?
+				cov::ProgramOptions::CoverageLevelLineValue :
+				cov::ProgramOptions::CoverageLevelSourceValue));
+			
+			return options;
+		}
 	}
 		
 	//-------------------------------------------------------------------------
@@ -50,6 +62,7 @@ namespace CppCoverageTest
 		ASSERT_FALSE(options->IsOptimizedBuildSupportEnabled());
 		ASSERT_TRUE(options->GetExcludedLineRegexes().empty());
 		ASSERT_TRUE(options->GetSubstitutePdbSourcePaths().empty());
+		ASSERT_EQ(options->GetCoverageLevel(), cov::CoverageLevel::Line);
 	}
 
 	//-------------------------------------------------------------------------
@@ -86,6 +99,24 @@ namespace CppCoverageTest
 		{ optionShortPrefix + cov::ProgramOptions::QuietShortOption })->GetLogLevel());
 		ASSERT_EQ(cov::LogLevel::Quiet, TestTools::Parse(parser,
 		{ TestTools::GetOptionPrefix() + cov::ProgramOptions::QuietOption })->GetLogLevel());
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(OptionsParserTest, LineLevelCoverage)
+	{
+		cov::OptionsParser parser;
+
+		ASSERT_EQ(cov::CoverageLevel::Line, TestTools::Parse(parser,
+			BuildCoverageLevelOption(cov::CoverageLevel::Line, TestTools::GetOptionPrefix()))->GetCoverageLevel());
+	}
+
+	//-------------------------------------------------------------------------
+	TEST(OptionsParserTest, SourceLevelCoverage)
+	{
+		cov::OptionsParser parser;
+
+		ASSERT_EQ(cov::CoverageLevel::Source, TestTools::Parse(parser,
+			BuildCoverageLevelOption(cov::CoverageLevel::Source, TestTools::GetOptionPrefix()))->GetCoverageLevel());
 	}
 
 	//-------------------------------------------------------------------------

--- a/CppCoverageTest/TestTools.cpp
+++ b/CppCoverageTest/TestTools.cpp
@@ -20,6 +20,7 @@
 #include <filesystem>
 #include <boost/algorithm/string.hpp>
 
+#include "CppCoverage/CoverageLevel.hpp"
 #include "CppCoverage/StartInfo.hpp"
 #include "CppCoverage/Debugger.hpp"
 #include "CppCoverage/IDebugEventsHandler.hpp"
@@ -105,16 +106,18 @@ namespace CppCoverageTest
 		Plugin::CoverageData ComputeCoverageData(
 			const std::vector<std::wstring>& arguments,
 			const std::wstring& modulePattern,
-			const std::wstring& sourcePattern)
+			const std::wstring& sourcePattern,
+			cov::CoverageLevel coverageLevel)
 		{
 			CoverageArgs args{ arguments, modulePattern, sourcePattern };
 
-			return ComputeCoverageDataPatterns(args);
+			return ComputeCoverageDataPatterns(args, coverageLevel);
 		}
 
 		//---------------------------------------------------------------------
 		Plugin::CoverageData ComputeCoverageDataPatterns(
-			const CoverageArgs& args)
+			const CoverageArgs& args,
+			cov::CoverageLevel coverageLevel)
 		{
 			cov::CodeCoverageRunner codeCoverageRunner{
 			    std::make_shared<Tools::WarningManager>()};
@@ -148,6 +151,7 @@ namespace CppCoverageTest
 			settings.SetCoverChildren(args.coverChildren_);
 			settings.SetContinueAfterCppException(args.continueAfterCppException_);
 			settings.SetOptimizedBuildSupport(args.optimizedBuildSupport_);
+			settings.SetCoverageLevel(coverageLevel);
 
 			auto coverageData = codeCoverageRunner.RunCoverage(settings);
 

--- a/CppCoverageTest/TestTools.hpp
+++ b/CppCoverageTest/TestTools.hpp
@@ -22,6 +22,7 @@
 #include <functional>
 #include <filesystem>
 
+#include "CppCoverage/CoverageLevel.hpp"
 #include "CppCoverage/OptionsParser.hpp"
 #include "CppCoverage/Options.hpp"
 #include "CppCoverage/SubstitutePdbSourcePath.hpp"
@@ -35,6 +36,17 @@ namespace CppCoverageTest
 {
 	namespace TestTools
 	{
+		class CoverageLevelTest : public ::testing::TestWithParam<CppCoverage::CoverageLevel>
+		{
+		protected:
+			const CppCoverage::CoverageLevel coverageLevel_ = GetParam();
+
+		};
+
+		const auto CoverageLevelValues = ::testing::Values(
+			CppCoverage::CoverageLevel::Line, CppCoverage::CoverageLevel::Source
+		);
+
 		using T_HandlesFct = std::function<void(HANDLE hProcess, HANDLE hFile)>;
 
 		void GetHandles(const std::filesystem::path&, T_HandlesFct);
@@ -72,10 +84,11 @@ namespace CppCoverageTest
 		Plugin::CoverageData ComputeCoverageData(
 			const std::vector<std::wstring>& arguments,
 			const std::wstring& modulePattern,
-			const std::wstring& sourcePattern);
+			const std::wstring& sourcePattern,
+			CppCoverage::CoverageLevel coverageLevel);
 
 		//---------------------------------------------------------------------
-		Plugin::CoverageData ComputeCoverageDataPatterns(const CoverageArgs& args);
+		Plugin::CoverageData ComputeCoverageDataPatterns(const CoverageArgs& args, CppCoverage::CoverageLevel coverageLevel);
 	}
 }
 

--- a/Exporter/Html/HtmlExporter.cpp
+++ b/Exporter/Html/HtmlExporter.cpp
@@ -56,10 +56,11 @@ namespace Exporter
 	const std::wstring HtmlExporter::WarningExitCodeMessage = L"Warning: Your program has exited with error code: ";
 
 	//-------------------------------------------------------------------------
-	HtmlExporter::HtmlExporter(const fs::path& templateFolder)
+	HtmlExporter::HtmlExporter(const fs::path& templateFolder, bool exportEmptyModules)
 		: exporter_(templateFolder / "MainTemplate.html", templateFolder / "SourceTemplate.html")
 		, fileCoverageExporter_()
 		, templateFolder_(templateFolder)
+		, exportEmptyModules_(exportEmptyModules)
 	{
 	}
 
@@ -99,7 +100,7 @@ namespace Exporter
 		{			
 			const auto& moduleCoverageRate = coverageRateComputer.GetCoverageRate(*module);
 
-			if (moduleCoverageRate.GetTotalLinesCount())
+			if (exportEmptyModules_ || moduleCoverageRate.GetTotalLinesCount())
 			{
 				const auto& modulePath = module->GetPath();
 				auto moduleFilename = module->GetPath().filename();

--- a/Exporter/Html/HtmlExporter.hpp
+++ b/Exporter/Html/HtmlExporter.hpp
@@ -51,7 +51,7 @@ namespace Exporter
 		static const std::wstring WarningExitCodeMessage;
 
 	public:
-		explicit HtmlExporter(const std::filesystem::path& templateFolder);
+		explicit HtmlExporter(const std::filesystem::path& templateFolder, bool exportEmptyModules);
 
 		std::filesystem::path GetDefaultPath(const std::wstring& prefix) const override;
 		void Export(const Plugin::CoverageData&, const std::filesystem::path& outputFolder) override;
@@ -74,6 +74,7 @@ namespace Exporter
 		TemplateHtmlExporter exporter_;
 		HtmlFileCoverageExporter fileCoverageExporter_;
 		std::filesystem::path templateFolder_;
+		bool exportEmptyModules_;
 	};
 }
 

--- a/Exporter/Html/Template/MainTemplate.html
+++ b/Exporter/Html/Template/MainTemplate.html
@@ -14,17 +14,34 @@
     <script type="text/javascript">
         $(document).ready(function ()
         {
+            function CreateCoverageChart(id, executedLine, unexecutedLine, coverRate, uncoverRate) {
+                if (executedLine === 0 && unexecutedLine === 0) {
+                    new RGraph.Pie(id, [0, 1])
+                    .set('labels', ['No line coverage data'])
+                    .set('colors', ['rgb(128,64,255)'])
+                    .set('linewidth', 1)
+                    .set('shadow', true)
+                    .set('tooltips', ['Unknown coverage'])
+                    .set('tooltips.event', 'onmousemove')
+                    .set('labels.sticks', false)
+                    .draw();
+                }
+                else {
+                    new RGraph.Pie(id, [executedLine, unexecutedLine])
+                    .set('labels', ['Cover ' + coverRate + '%', 'Uncover ' + uncoverRate + '%'])
+                    .set('colors', ['rgb(0,255,0)', 'rgb(255,0,0)'])
+                    .set('linewidth', 1)
+                    .set('shadow', true)
+                    .set('tooltips', ['cover ' + executedLine + ' lines (' + coverRate + '%)', 'uncover ' + unexecutedLine + ' lines (' + uncoverRate + '%)'])
+                    .set('tooltips.event', 'onmousemove')
+                    .set('labels.sticks', true)
+                    .set('labels.sticks.length', 10)
+                    .draw();
+                }   
+            }
+
             {{#ITEMS}}
-            new RGraph.Pie('pi_{{ID}}', [{{EXECUTED_LINE}}, {{UNEXECUTED_LINE}}])
-                .set('labels', ['Cover {{COVER_RATE}}%','Uncover {{UNCOVER_RATE}}%'])
-                .set('colors', ['rgb(0,255,0)','rgb(255,0,0)'])
-                .set('linewidth', 1)
-                .set('shadow', true)
-                .set('tooltips', ['cover {{EXECUTED_LINE}} lines ({{COVER_RATE}}%)', 'uncover {{UNEXECUTED_LINE}} lines ({{UNCOVER_RATE}}%)'])
-                .set('tooltips.event', 'onmousemove')
-                .set('labels.sticks', true)
-                .set('labels.sticks.length', 10)
-                .draw();
+            CreateCoverageChart('pi_{{ID}}', {{EXECUTED_LINE}}, {{UNEXECUTED_LINE}}, {{COVER_RATE}}, {{UNCOVER_RATE}});
             {{/ITEMS}}
 
       })

--- a/ExporterTest/HtmlExporterTest.cpp
+++ b/ExporterTest/HtmlExporterTest.cpp
@@ -36,11 +36,11 @@ namespace fs = std::filesystem;
 namespace ExporterTest
 {
 	//-------------------------------------------------------------------------
-	struct HtmlExporterTest : public ::testing::Test
+	struct HtmlExporterTest : public ::testing::TestWithParam<bool>
 	{
 		//-------------------------------------------------------------------------
 		HtmlExporterTest()
-			: htmlExporter_{ fs::canonical(OUT_DIR) / "Template" }
+			: htmlExporter_{ fs::canonical(OUT_DIR) / "Template", GetParam() }
 		{
 
 		}
@@ -75,7 +75,7 @@ namespace ExporterTest
 	};	
 
 	//-------------------------------------------------------------------------
-	TEST_F(HtmlExporterTest, Export)
+	TEST_P(HtmlExporterTest, Export)
 	{	
 		fs::path testFolder = fs::path(PROJECT_DIR) / "Data";
 		Plugin::CoverageData data{ L"Test", 0};
@@ -96,13 +96,13 @@ namespace ExporterTest
 		auto modulesPath = output_.GetPath() / Exporter::HtmlFolderStructure::FolderModules;
 		ASSERT_TRUE(Tools::FileExists(output_.GetPath() / "index.html"));
 		ASSERT_TRUE(Tools::FileExists(modulesPath / "module1.html"));
-		ASSERT_FALSE(Tools::FileExists(modulesPath / "module2.html"));
+		ASSERT_EQ(Tools::FileExists(modulesPath / "module2.html"), GetParam());
 		ASSERT_TRUE(Tools::FileExists(modulesPath / "module1" / (filename1 + L".html")));
 		ASSERT_TRUE(Tools::FileExists(modulesPath / "module1" / (filename2 + L".html")));
 	}
 
 	//-------------------------------------------------------------------------
-	TEST_F(HtmlExporterTest, NoWarning)
+	TEST_P(HtmlExporterTest, NoWarning)
 	{
 		Plugin::CoverageData data{ L"Test", 0 };
 
@@ -111,7 +111,7 @@ namespace ExporterTest
 	}
 
 	//-------------------------------------------------------------------------
-	TEST_F(HtmlExporterTest, Warning)
+	TEST_P(HtmlExporterTest, Warning)
 	{
 		Plugin::CoverageData data{ L"Test", 42};
 
@@ -120,7 +120,7 @@ namespace ExporterTest
 	}
 
 	//-------------------------------------------------------------------------
-	TEST_F(HtmlExporterTest, SubFolderDoesNotExist)
+	TEST_P(HtmlExporterTest, SubFolderDoesNotExist)
 	{
 		Plugin::CoverageData data{ L"Test", 42 };
 		auto outputFolder = output_.GetPath() / "SubFolder1" / "SubFolder2";
@@ -131,7 +131,7 @@ namespace ExporterTest
 	}
 
 	//-------------------------------------------------------------------------
-	TEST_F(HtmlExporterTest, OutputExists)
+	TEST_P(HtmlExporterTest, OutputExists)
 	{
 		Plugin::CoverageData data{ L"Test", 42 };
 		TestHelper::TemporaryPath outputFolder{ TestHelper::TemporaryPathOption::CreateAsFolder };
@@ -140,7 +140,7 @@ namespace ExporterTest
 	}
 
 	//-------------------------------------------------------------------------
-	TEST_F(HtmlExporterTest, SameModuleSameSourceFile)
+	TEST_P(HtmlExporterTest, SameModuleSameSourceFile)
 	{
 		Plugin::CoverageData data{ L"Test", 0 };
 		const std::wstring filename = L"TestFile1.cpp";
@@ -160,5 +160,12 @@ namespace ExporterTest
 		ASSERT_TRUE(Tools::FileExists(modulesPath / "module" / (filename + L"2.html")));
 		ASSERT_TRUE(Tools::FileExists(modulesPath / "module.html"));
 	}
+
+	INSTANTIATE_TEST_SUITE_P(
+		HtmlExporterTests,
+		HtmlExporterTest,
+		::testing::Values(
+			false, true
+		));
 }
 

--- a/OpenCppCoverage/OpenCppCoverage.cpp
+++ b/OpenCppCoverage/OpenCppCoverage.cpp
@@ -88,7 +88,8 @@ namespace OpenCppCoverage
 			std::map<cov::OptionsExportType, std::unique_ptr<Exporter::IExporter>> exporters;
 			
 			exporters.emplace(cov::OptionsExportType::Html, 
-				std::unique_ptr<Exporter::IExporter>(std::make_unique<Exporter::HtmlExporter>( GetTemplateFolder() )));
+				std::unique_ptr<Exporter::IExporter>(std::make_unique<Exporter::HtmlExporter>( 
+					GetTemplateFolder(), options.GetCoverageLevel() == cov::CoverageLevel::Source)));
 			exporters.emplace(cov::OptionsExportType::Cobertura, 
 				std::unique_ptr<Exporter::IExporter>(std::make_unique<Exporter::CoberturaExporter>()));
 			exporters.emplace(cov::OptionsExportType::Binary,
@@ -238,7 +239,7 @@ namespace OpenCppCoverage
 			}
 			catch (...)
 			{
-				LOG_ERROR << "Unkown Error";
+				LOG_ERROR << "Unknown Error";
 			}
 
 			warningManager->DisplayWarnings();

--- a/OpenCppCoverage/OpenCppCoverage.cpp
+++ b/OpenCppCoverage/OpenCppCoverage.cpp
@@ -19,6 +19,7 @@
 
 #include <iostream>
 
+#include "CppCoverage/CoverageLevel.hpp"
 #include "CppCoverage/CodeCoverageRunner.hpp"
 #include "CppCoverage/CoverageFilterSettings.hpp"
 #include "CppCoverage/OptionsParser.hpp"
@@ -182,6 +183,7 @@ namespace OpenCppCoverage
                 runCoverageSettings.SetStopOnAssert(options.IsStopOnAssertModeEnabled());
                 runCoverageSettings.SetMaxUnmatchPathsForWarning(maxUnmatchPathsForWarning);
 				runCoverageSettings.SetOptimizedBuildSupport(options.IsOptimizedBuildSupportEnabled());
+				runCoverageSettings.SetCoverageLevel(options.GetCoverageLevel());
 				auto coverageData = codeCoverageRunner.RunCoverage(runCoverageSettings);
 				exitCode = coverageData.GetExitCode();
 				coveraDatas.push_back(std::move(coverageData));


### PR DESCRIPTION
# What Is This Feature?

This feature adds an additional coverage method at the source level whereupon no breakpoints are placed on executable statements. This allows for OpenCppCoverage to generate coverage in two mutually exclusive ways: source level (mapping test runs to target sources) and line level (mapping test runs to executable lines of target sources).

# Why Is This Feature Needed?

## Problem
Line level coverage tests run significantly slower than regular non-OpenCppCoverage runs (hereafter referred to as uninstrumented runs) of the same tests. The duration of line level coverage tests scales with the number of sources parsed and breakpoints placed (see below for measurement data). This runtime performance penalty makes line level coverage impractical for use cases where large volumes of tests are required to be run on a regular basis (e.g. as part of a CI pipeline).

## Proposed Solution
Source level coverage provides a significant performance boost over line level coverage, putting it on par with uninstrumented test runs, albeit at the cost of granularity. It achieves this by skipping the breakpoint placement stage of instrumentation and instead assuming that a given enumerated source file is covered regardless of whether or not any executable
lines of code were covered by the test. This can result in false positives (sources enumerated as covered but not actually covered) but will not result in false negatives (sources not enumerated but covered) any more than line level coverage will. This speed increase and lack of false negatives make it ideal for use cases where the coverage data of previous test runs is used to select and prioritize tests for subsequent runs (e.g. test impact analysis).

## Measurment Data

The data below shows the timing results for an uninstrumented test run, a source level coverage test run and a line level coverage test run for two real-world test suites. The difference between the uninstrumented timings and the line level coverage timings is stark with the latter being approx. 24x to 250x slower. However, the difference between the uninstrumented timings and the source level coverage timings is less so, being only approx. 3x to 4x slower.

| Test Suite | Sources Covered | Executable Lines | Uninstrumented | Source level | Line Level |
|------------|-----------------|------------------|----------------|--------------|------------|
| Medium     | 2,354           | 1,648,628        | 20s94ms        | 1m03s12ms    | 8m00s21ms  |
| Small      | 379             | 263,015          | 12ms           | 48ms         | 30s26ms    |


# How Is This Feature Implemented?

## Overview
A new enum, `CoverageLevel`, is added. Currently, this enum lives alone in `CoverageLevel.h` due to the inability to appropriately share this state representation between the options & configuration code and the coverage logic code. This enum determines the type of coverage that will be generated: `CoverageLevel::Line` (the default) and `CoverageLevel::Source`.

In order to keep the `DebugInformationEnumerator` class agnostic of the concept of modules, the `Enumerate` method has been broken into two further methods specialized for each coverage type: `EnumerateSourceLevel` and `EnumerateLineLevel`. The former operates much in the same manner as the original `Enumerate` method whereas the latter accepts an additional argument in the form of a vector of path types that the method will populate with the enumerated source files.

The caller of `EnumerateSourceLevel` is responsible for updating the pertinent module with the enumerated source paths. This is to ensure that the module will still have its source file list populated even though no breakpoints are placed & triggered.

## Exporters

The only exporter affected by this change was the HTML exporter. As the logic of this exporter skipped over moduled that had zero executed lines, this was modified to allow this specific part of the logic to be overridden by a flag signifying that empty modules should still be exported.

The HTML template for this exporter was also modified to correctly handle source level coverage where the `RGraph` pie charts had zero values for the executed and unexecuted line vars. In such circumstances, a purple pie chart is rendered with a label informing the user that no line level coverage is available (see image below). This modification was made at this level to keep the modifications to the HTML exporter as unintrusive as possible.

**Example Index Page (modules anonymized)**
![image](https://user-images.githubusercontent.com/77458631/107242560-04fd2d00-6a24-11eb-963e-3998bd373581.png)

**Example Module Breakdown (sources anonymized)**
![image](https://user-images.githubusercontent.com/77458631/107237402-9bc6eb00-6a1e-11eb-9861-55059c2de292.png)

# Testing Done

### Existing Tests

All tests pass except `CodeCoverageRunnerTest.OptimizedBuild` which currently fails with and without the new changes.

### Additional Tests

**CppCoverageTest**

The `CodeCoverageRunnerTest` and `CppCliTest` fixtures have been modified to be parametrized test fixtures, covering both `CoverageLevel::Line` and `CoverageLevel::Source` permutations. The `DebugInformationEnumeratorTest` fixture has the `Enumerate` test replaced with `EmumerateLineLevel` and `EnumerateSourceLevel` tests. The `OptionsParserTest.Default` test has been modified to include the new `--coverage_level` option (and its default value) and the fixture itself has additional tests to cover this new option.

All tests pass.

**HtmlExporterTest**

The fixture has been modified to be parametrized test fixtures, covering the permutations for the `exportEmptyModules` constructor flag. The `HtmlExporterTest.Export` test has been modified to handle the the assertion that empty modules should or not be exported depending on the flag value.

All tests pass.
