### PR TITLE
Ignore unhandled exception used for VS thread name

### DIFF
--- a/CppCoverage/CodeCoverageRunner.cpp
+++ b/CppCoverage/CodeCoverageRunner.cpp
@@ -160,6 +160,12 @@ namespace CppCoverage
 
 				return IDebugEventsHandler::ExceptionType::CppError;
 			}
+			case CppCoverage::ExceptionHandlerStatus::SetThreadName:
+			{
+				LOG_ERROR << ostr.str();
+
+				return IDebugEventsHandler::ExceptionType::SetThreadName;
+			}
 		}
 
 		return IDebugEventsHandler::ExceptionType::NotHandled;

--- a/CppCoverage/Debugger.cpp
+++ b/CppCoverage/Debugger.cpp
@@ -177,6 +177,7 @@ namespace CppCoverage
 		switch (exceptionType)
 		{
 			case IDebugEventsHandler::ExceptionType::BreakPoint:
+			case IDebugEventsHandler::ExceptionType::SetThreadName:
 			{
 				return ProcessStatus{ boost::none, DBG_CONTINUE };
 			}

--- a/CppCoverage/ExceptionHandler.cpp
+++ b/CppCoverage/ExceptionHandler.cpp
@@ -27,10 +27,12 @@ namespace CppCoverage
 	const std::wstring ExceptionHandler::UnhandledExceptionErrorMessage =
 	    L"Your application has thrown an unhandled exception. Code: ";
 	const std::wstring ExceptionHandler::ExceptionCpp = L"Exception C++";
+	const std::wstring ExceptionHandler::ExceptionSetThreadName = L"MS_VC_EXCEPTION (set thread name)";
 	const std::wstring ExceptionHandler::ExceptionAccesViolation = L"EXCEPTION_ACCESS_VIOLATION";
 	const std::wstring ExceptionHandler::ExceptionUnknown = L"Unknown";
 	const int ExceptionHandler::ExceptionEmulationX86ErrorCode = 0x4000001f;
 	const int ExceptionHandler::CppExceptionErrorCode = 0xE06D7363;
+	const int ExceptionHandler::SetThreadNameExceptionErrorCode = 0x406D1388;
 
 	//-------------------------------------------------------------------------
 	ExceptionHandler::ExceptionHandler()
@@ -65,6 +67,7 @@ namespace CppCoverage
 		exceptionCode_.emplace(EXCEPTION_STACK_OVERFLOW, L"EXCEPTION_STACK_OVERFLOW");
 		
 		exceptionCode_.emplace(CppExceptionErrorCode, ExceptionCpp);
+		exceptionCode_.emplace(SetThreadNameExceptionErrorCode, ExceptionSetThreadName);
 	}
 	
 	//-------------------------------------------------------------------------
@@ -99,9 +102,15 @@ namespace CppCoverage
 		message << UnhandledExceptionErrorMessage << exceptionRecord.ExceptionCode;
 		message << L": " << GetExceptionStrFromCode(exceptionRecord.ExceptionCode) << std::endl;
 		message << Tools::GetSeparatorLine() << std::endl;
+		if (exceptionCode == SetThreadNameExceptionErrorCode)
+		{
+			message << L" Ignoring attempt to set thread name and continuing." << std::endl;
+			return ExceptionHandlerStatus::SetThreadName;
+		}
 		message << L"See https://github.com/OpenCppCoverage/OpenCppCoverage/wiki/FAQ";
 		message << L"#your-application-has-thrown-an-unhandled-exception-code-3221225477";
 		message << L"-exception_access_violation for additional information." << std::endl;
+
 
 		return (exceptionCode == CppExceptionErrorCode) 
 			? ExceptionHandlerStatus::CppError : ExceptionHandlerStatus::Error;

--- a/CppCoverage/ExceptionHandler.hpp
+++ b/CppCoverage/ExceptionHandler.hpp
@@ -30,7 +30,8 @@ namespace CppCoverage
 		BreakPoint,
 		FirstChanceException,
 		Error,
-		CppError
+		CppError,
+		SetThreadName
 	};
 
 	class CPPCOVERAGE_DLL ExceptionHandler
@@ -38,10 +39,12 @@ namespace CppCoverage
 	public:
 		static const std::wstring UnhandledExceptionErrorMessage;
 		static const std::wstring ExceptionCpp;
+		static const std::wstring ExceptionSetThreadName;
 		static const std::wstring ExceptionAccesViolation;
 		static const std::wstring ExceptionUnknown;
 		static const int ExceptionEmulationX86ErrorCode;
 		static const int CppExceptionErrorCode;
+		static const int SetThreadNameExceptionErrorCode;
 
 		ExceptionHandler();
 

--- a/CppCoverage/IDebugEventsHandler.hpp
+++ b/CppCoverage/IDebugEventsHandler.hpp
@@ -31,7 +31,8 @@ namespace CppCoverage
 			InvalidBreakPoint,
 			NotHandled,
 			Error,
-			CppError
+			CppError,
+			SetThreadName
 		};
 
 		IDebugEventsHandler() = default;

--- a/CppCoverageTest/ExceptionHandlerTest.cpp
+++ b/CppCoverageTest/ExceptionHandlerTest.cpp
@@ -95,6 +95,14 @@ namespace CppCoverageTest
 	}
 
 	//-----------------------------------------------------------------------------
+	TEST_F(ExceptionHandlerTest, TestUnHandleSetThreadName)
+	{
+		Run(TestCoverageConsole::TestSetThreadNameException);
+		ASSERT_EQ(cov::ExceptionHandlerStatus::SetThreadName, exceptionHandlerStatus_);
+		ASSERT_NE(std::string::npos, message_.find(cov::ExceptionHandler::ExceptionSetThreadName));
+	}
+
+	//-----------------------------------------------------------------------------
 	TEST_F(ExceptionHandlerTest, TestUnHandleSEHException)
 	{
 		Run(TestCoverageConsole::TestThrowUnHandledSEHException);	

--- a/TestCoverageConsole/TestCoverageConsole.cpp
+++ b/TestCoverageConsole/TestCoverageConsole.cpp
@@ -42,7 +42,28 @@ namespace
 		catch (...)
 		{
 		}
-	}	
+	}
+
+	//-----------------------------------------------------------------------------
+	void ThrowUnhandledSetThreadName()
+	{
+		const DWORD MS_VC_EXCEPTION = 0x406D1388;
+#pragma pack(push,8)
+		typedef struct tagTHREADNAME_INFO
+		{
+			DWORD dwType; // Must be 0x1000.
+			LPCSTR szName; // Pointer to name (in user addr space).
+			DWORD dwThreadID; // Thread ID (-1=caller thread).
+			DWORD dwFlags; // Reserved for future use, must be zero.
+		} THREADNAME_INFO;
+#pragma pack(pop)
+		THREADNAME_INFO info;
+		info.dwType = 0x1000;
+		info.szName = "TestSetThreadName";
+		info.dwThreadID = -1;
+		info.dwFlags = 0;
+		RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
+	}
 
 	//-----------------------------------------------------------------------------
 	void TestFileInSeveralModules()
@@ -89,6 +110,8 @@ int _tmain(int argc, _TCHAR* argv[])
 			TestCoverageConsole::FilterByDiff();
 		else if (type == TestCoverageConsole::TestOptimizedBuild)
 			TestCoverageOptimizedBuild::TestOptimizedBuild();
+		else if (type == TestCoverageConsole::TestSetThreadNameException)
+			ThrowUnhandledSetThreadName();
 		else
 			std::wcerr << L"Unsupported type:" << type << std::endl;
 	}

--- a/TestCoverageConsole/TestCoverageConsole.hpp
+++ b/TestCoverageConsole/TestCoverageConsole.hpp
@@ -42,13 +42,13 @@ namespace TestCoverageConsole
 	//-------------------------------------------------------------------------
 	inline int GetTestCoverageConsoleCppMainStartLine()
 	{
-		return 56;
+		return 77;
 	}
 
 	//-------------------------------------------------------------------------
 	inline int GetTestCoverageConsoleCppMainReturnLine()
 	{
-		return GetTestCoverageConsoleCppMainStartLine() + 39;
+		return GetTestCoverageConsoleCppMainStartLine() + 41;
 	}
 
 	const std::wstring TestBasic = L"TestBasic";
@@ -56,6 +56,7 @@ namespace TestCoverageConsole
 	const std::wstring TestSharedLib = L"TestSharedLib";
 	const std::wstring TestThrowHandledException = L"TestThrowHandledException";
 	const std::wstring TestThrowUnHandledCppException = L"TestThrowUnHandledCppException";
+	const std::wstring TestSetThreadNameException = L"TestSetThreadNameException";
 	const std::wstring TestThrowUnHandledSEHException = L"TestThrowUnHandledSEHException";
 	const std::wstring TestBreakPoint = L"TestBreakPoint";
 	const std::wstring TestChildProcess = L"ChildProcess";


### PR DESCRIPTION
Fixes Issue #141.

SEH raising MS_VS_EXCEPTION (0x406d1388) is used to set
thread names in the Visual Studio debugger.  Applications
are supposed to catch it as well, but in case they do not
just emit a warning message and continue.