### PR TITLE
Prevent an infinite loop when a breakpoint was patched out

### DIFF
--- a/CppCoverage/CodeCoverageRunner.cpp
+++ b/CppCoverage/CodeCoverageRunner.cpp
@@ -178,9 +178,17 @@ namespace CppCoverage
 
 		if (oldInstruction)
 		{
-			breakpoint_->RemoveBreakPoint(address, *oldInstruction);
-			breakpoint_->AdjustEipAfterBreakPointRemoval(hThread);
-			return true;
+			if (*oldInstruction != BreakPoint::breakPointInstruction)
+			{
+				breakpoint_->RemoveBreakPoint(address, *oldInstruction);
+				breakpoint_->AdjustEipAfterBreakPointRemoval(hThread);
+				return true;
+			}
+			else
+			{
+				// There was already a BP instruction here!
+				return false;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
This would hang forever, since the 'original' breakpoint would be patched back in and eip/rip decremented.