### PR TITLE
Add quotes around path

### DIFF
--- a/InstallThirdPartyLibraries.ps1
+++ b/InstallThirdPartyLibraries.ps1
@@ -2,4 +2,4 @@ Invoke-WebRequest -OutFile nuget.exe https://dist.nuget.org/win-x86-commandline/
 Invoke-WebRequest -OutFile ThirdParty.1.4.0.nupkg https://github.com/OpenCppCoverage/OpenCppCoverageThirdParty/releases/download/1.4.0/ThirdParty.1.4.0.nupkg
 
 $scriptFolder = Split-Path $script:MyInvocation.MyCommand.Path
-Invoke-Expression "./nuget.exe install ThirdParty -Source $scriptFolder -OutputDirectory packages"
+Invoke-Expression "./nuget.exe install ThirdParty -Source '$scriptFolder' -OutputDirectory packages"


### PR DESCRIPTION
To prevent errors in paths containing spaces quotes are added around the
-Source parameter of the nuget call

Signed-off-by: Pengolodth Goedath <pengolodh.goedath@gmail.com>