### PR TITLE
Coverage on native part of mixed-mode assemblies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ CoverageData.pb.h
 CoverageData.pb.cc
 
 .clang-format
+TestMixedMode/obj/

--- a/CppCoverage.sln
+++ b/CppCoverage.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31605.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2D036BFA-5FAC-467B-9648-5B2BBC5B872C}"
 	ProjectSection(SolutionItems) = preProject
@@ -16,7 +16,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CppCoverageTest", "CppCoverageTest\CppCoverageTest.vcxproj", "{4360D299-2F7D-462E-B7EF-0670FD06F478}"
 	ProjectSection(ProjectDependencies) = postProject
 		{21A0DD74-91CB-485A-BACD-A18047E076D8} = {21A0DD74-91CB-485A-BACD-A18047E076D8}
+		{D95BBB9A-66FF-44DB-B630-99C700CC31C9} = {D95BBB9A-66FF-44DB-B630-99C700CC31C9}
 		{A50DD5A6-E85A-4E0B-9CC6-90D32503CE62} = {A50DD5A6-E85A-4E0B-9CC6-90D32503CE62}
+		{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6} = {958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}
 		{0DD16EDF-BD43-4D7B-B357-931F48F2FCC6} = {0DD16EDF-BD43-4D7B-B357-931F48F2FCC6}
 	EndProjectSection
 EndProject
@@ -56,6 +58,10 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Plugin", "Plugin\Plugin.vcxproj", "{2F439508-07E0-4084-9614-1A42BDE8ED9A}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginTest", "PluginTest\PluginTest.vcxproj", "{69AA0B9B-DA99-4B28-B3FC-49AC3AD0A88A}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestMixedModeLibrary", "TestMixedModeLibrary\TestMixedModeLibrary.vcxproj", "{D95BBB9A-66FF-44DB-B630-99C700CC31C9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestMixedMode", "TestMixedMode\TestMixedMode.csproj", "{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -201,6 +207,22 @@ Global
 		{69AA0B9B-DA99-4B28-B3FC-49AC3AD0A88A}.Release|Win32.Build.0 = Release|Win32
 		{69AA0B9B-DA99-4B28-B3FC-49AC3AD0A88A}.Release|x64.ActiveCfg = Release|x64
 		{69AA0B9B-DA99-4B28-B3FC-49AC3AD0A88A}.Release|x64.Build.0 = Release|x64
+		{D95BBB9A-66FF-44DB-B630-99C700CC31C9}.Debug|Win32.ActiveCfg = Debug|Win32
+		{D95BBB9A-66FF-44DB-B630-99C700CC31C9}.Debug|Win32.Build.0 = Debug|Win32
+		{D95BBB9A-66FF-44DB-B630-99C700CC31C9}.Debug|x64.ActiveCfg = Debug|x64
+		{D95BBB9A-66FF-44DB-B630-99C700CC31C9}.Debug|x64.Build.0 = Debug|x64
+		{D95BBB9A-66FF-44DB-B630-99C700CC31C9}.Release|Win32.ActiveCfg = Release|Win32
+		{D95BBB9A-66FF-44DB-B630-99C700CC31C9}.Release|Win32.Build.0 = Release|Win32
+		{D95BBB9A-66FF-44DB-B630-99C700CC31C9}.Release|x64.ActiveCfg = Release|x64
+		{D95BBB9A-66FF-44DB-B630-99C700CC31C9}.Release|x64.Build.0 = Release|x64
+		{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}.Debug|Win32.ActiveCfg = Debug|x86
+		{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}.Debug|Win32.Build.0 = Debug|x86
+		{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}.Debug|x64.ActiveCfg = Debug|x64
+		{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}.Debug|x64.Build.0 = Debug|x64
+		{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}.Release|Win32.ActiveCfg = Release|x86
+		{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}.Release|Win32.Build.0 = Release|x86
+		{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}.Release|x64.ActiveCfg = Release|x64
+		{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CppCoverage/DebugInformationEnumerator.cpp
+++ b/CppCoverage/DebugInformationEnumerator.cpp
@@ -317,10 +317,11 @@ namespace CppCoverage
 				probe = parent;
 			}
 
-			// by observation this fails for managed functions
-			CComPtr<IDiaSymbol> pBaseType;
-			auto check = probe->get_type(&pBaseType);
-			if (check != S_OK) {
+			// by observation this fails (S_FALSE) for unmanaged functions
+                        // which of course have no metadata token value
+			DWORD token{ 0 };
+			auto check = probe->get_token(&token);
+			if (check == S_OK && token != 0) {
 				return;
 			}
 

--- a/CppCoverageTest/CppCliTest.cpp
+++ b/CppCoverageTest/CppCliTest.cpp
@@ -66,7 +66,10 @@ namespace CppCoverageTest
 		coverageArgs.modulePatternCollection_.push_back(
 		    sharedMixedModeLibModulePath.wstring());
 		coverageArgs.programToRun_ = vsConsoleTestPath;
-		coverageArgs.arguments_.push_back(L"--platform:x64");
+		if (sizeof(void*) == 8)
+			coverageArgs.arguments_.push_back(L"--platform:x64");
+		else
+			coverageArgs.arguments_.push_back(L"--platform:x86");
 
 		auto coverage = TestTools::ComputeCoverageDataPatterns(coverageArgs);
 		ASSERT_EQ(0, coverage.GetExitCode());

--- a/CppCoverageTest/CppCliTest.cpp
+++ b/CppCoverageTest/CppCliTest.cpp
@@ -50,4 +50,28 @@ namespace CppCoverageTest
 		ASSERT_EQ(testCppCliPath, modules.at(0)->GetPath());
 		ASSERT_EQ(sharedLibModulePath, modules.at(1)->GetPath());
 	}
+
+	//---------------------------------------------------------------------
+	TEST(CppCliTest, ManagedMixedModule)
+	{
+		auto vsPath = TestHelper::GetVisualStudioPath();
+		fs::path vsConsoleTestPath = vsPath / "Common7" / "IDE" /
+		                             "CommonExtensions" / "Microsoft" /
+		                             "TestWindow" / "vstest.console.exe";
+		auto testMixedModePath = (fs::path{OUT_DIR} / "TestMixedMode.dll").wstring();
+		auto sharedMixedModeLibModulePath = fs::path{OUT_DIR} / "TestMixedModeLibrary.dll";
+
+		TestTools::CoverageArgs coverageArgs(
+		    {testMixedModePath}, testMixedModePath, L"None");
+		coverageArgs.modulePatternCollection_.push_back(
+		    sharedMixedModeLibModulePath.wstring());
+		coverageArgs.programToRun_ = vsConsoleTestPath;
+		coverageArgs.arguments_.push_back(L"--platform:x64");
+
+		auto coverage = TestTools::ComputeCoverageDataPatterns(coverageArgs);
+		ASSERT_EQ(0, coverage.GetExitCode());
+		const auto& modules = coverage.GetModules();
+		ASSERT_EQ(1, modules.size());
+		ASSERT_EQ(sharedMixedModeLibModulePath, modules.at(0)->GetPath());
+	}
 }

--- a/CppCoverageTest/CppCliTest.cpp
+++ b/CppCoverageTest/CppCliTest.cpp
@@ -46,7 +46,8 @@ namespace CppCoverageTest
 		auto coverage = TestTools::ComputeCoverageDataPatterns(coverageArgs);
 		ASSERT_EQ(0, coverage.GetExitCode());
 		const auto& modules = coverage.GetModules();
-		ASSERT_EQ(1, modules.size());
-		ASSERT_EQ(sharedLibModulePath, modules.at(0)->GetPath());
+		ASSERT_EQ(2, modules.size());
+		ASSERT_EQ(testCppCliPath, modules.at(0)->GetPath());
+		ASSERT_EQ(sharedLibModulePath, modules.at(1)->GetPath());
 	}
 }

--- a/TestMixedMode/Properties/AssemblyInfo.cs
+++ b/TestMixedMode/Properties/AssemblyInfo.cs
@@ -1,8 +1,24 @@
-﻿using System.Reflection;
+﻿// OpenCppCoverage is an open source code coverage for C++.
+// Copyright (C) 2017 OpenCppCoverage
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("TestMixedMode")]
@@ -14,8 +30,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -25,12 +41,12 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyFileVersion("1.0.*")]

--- a/TestMixedMode/Properties/AssemblyInfo.cs
+++ b/TestMixedMode/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestMixedMode")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestMixedMode")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("958df9b2-c3e2-4b72-ab1c-8969158deab6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TestMixedMode/TestMixedMode.csproj
+++ b/TestMixedMode/TestMixedMode.csproj
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{958DF9B2-C3E2-4B72-AB1C-8969158DEAB6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TestMixedMode</RootNamespace>
+    <AssemblyName>TestMixedMode</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>$(SolutionDir)\Debug</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>$(SolutionDir)\x64\Debug</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>$(SolutionDir)\Release</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>$(SolutionDir)x64\Release</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="UnitTest1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TestMixedModeLibrary\TestMixedModeLibrary.vcxproj">
+      <Project>{D95BBB9A-66FF-44DB-B630-99C700CC31C9}</Project>
+      <Name>TestMixedModeLibrary</Name>
+    </ProjectReference>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+      <HintPath>$(VS160COMNTOOLS)..\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/TestMixedMode/UnitTest1.cs
+++ b/TestMixedMode/UnitTest1.cs
@@ -1,0 +1,15 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TestMixedMode
+{
+    [TestClass]
+    public class Tests
+    {
+        [TestMethod]
+        public void TestCount()
+        {
+            var subject = new TestMixedModeLibrary.Mixed();
+            Assert.AreEqual(12, subject.CountVowels("The quick brown fox jumped over the lazy dog."));
+        }
+    }
+}

--- a/TestMixedMode/UnitTest1.cs
+++ b/TestMixedMode/UnitTest1.cs
@@ -1,3 +1,19 @@
+// OpenCppCoverage is an open source code coverage for C++.
+// Copyright (C) 2017 OpenCppCoverage
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace TestMixedMode

--- a/TestMixedModeLibrary/AssemblyInfo.cpp
+++ b/TestMixedModeLibrary/AssemblyInfo.cpp
@@ -1,6 +1,3 @@
-// DllForCppCoverageTest.cpp : Defines the entry point for the application.
-//
-
 #include "Stdafx.h"
 
 // OpenCppCoverage is an open source code coverage for C++.
@@ -19,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include "Stdafx.h"
+
 using namespace System::Reflection;
 using namespace System::Runtime::CompilerServices;
 using namespace System::Runtime::InteropServices;
@@ -28,11 +27,11 @@ using namespace System::Runtime::InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 //
-[assembly:AssemblyTitleAttribute("TestCppCli")];
+[assembly:AssemblyTitleAttribute("TestMixedModeLibrary")];
 [assembly:AssemblyDescriptionAttribute("")] ;
 [assembly:AssemblyConfigurationAttribute("")] ;
 [assembly:AssemblyCompanyAttribute("")] ;
-[assembly:AssemblyProductAttribute("TestCppCli")] ;
+[assembly:AssemblyProductAttribute("TestMixedModeLibrary")] ;
 [assembly:AssemblyCopyrightAttribute("Copyright (c)  2017")] ;
 [assembly:AssemblyTrademarkAttribute("")] ;
 [assembly:AssemblyCultureAttribute("")] ;
@@ -48,5 +47,5 @@ using namespace System::Runtime::InteropServices;
 // You can specify all the value or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 
-[assembly:AssemblyVersionAttribute("1.0.0.0")];
+[assembly:AssemblyVersionAttribute("1.0.*")];
 [assembly:ComVisible(false)] ;

--- a/TestMixedModeLibrary/AssemblyInfo.cpp
+++ b/TestMixedModeLibrary/AssemblyInfo.cpp
@@ -1,0 +1,52 @@
+// DllForCppCoverageTest.cpp : Defines the entry point for the application.
+//
+
+#include "Stdafx.h"
+
+// OpenCppCoverage is an open source code coverage for C++.
+// Copyright (C) 2017 OpenCppCoverage
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using namespace System::Reflection;
+using namespace System::Runtime::CompilerServices;
+using namespace System::Runtime::InteropServices;
+
+//
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+//
+[assembly:AssemblyTitleAttribute("TestCppCli")];
+[assembly:AssemblyDescriptionAttribute("")] ;
+[assembly:AssemblyConfigurationAttribute("")] ;
+[assembly:AssemblyCompanyAttribute("")] ;
+[assembly:AssemblyProductAttribute("TestCppCli")] ;
+[assembly:AssemblyCopyrightAttribute("Copyright (c)  2017")] ;
+[assembly:AssemblyTrademarkAttribute("")] ;
+[assembly:AssemblyCultureAttribute("")] ;
+
+//
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the value or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+
+[assembly:AssemblyVersionAttribute("1.0.0.0")];
+[assembly:ComVisible(false)] ;

--- a/TestMixedModeLibrary/Stdafx.cpp
+++ b/TestMixedModeLibrary/Stdafx.cpp
@@ -1,0 +1,5 @@
+// stdafx.cpp : source file that includes just the standard includes
+// MixedMode.pch will be the pre-compiled header
+// stdafx.obj will contain the pre-compiled type information
+
+#include "stdafx.h"

--- a/TestMixedModeLibrary/Stdafx.cpp
+++ b/TestMixedModeLibrary/Stdafx.cpp
@@ -1,3 +1,20 @@
+// OpenCppCoverage is an open source code coverage for C++.
+// Copyright (C) 2017 OpenCppCoverage
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
 // stdafx.cpp : source file that includes just the standard includes
 // MixedMode.pch will be the pre-compiled header
 // stdafx.obj will contain the pre-compiled type information

--- a/TestMixedModeLibrary/Stdafx.h
+++ b/TestMixedModeLibrary/Stdafx.h
@@ -1,0 +1,8 @@
+// stdafx.h : include file for standard system include files,
+// or project specific include files that are used frequently,
+// but are changed infrequently
+
+#pragma once
+
+#include <vcclr.h>
+#include <wchar.h>

--- a/TestMixedModeLibrary/Stdafx.h
+++ b/TestMixedModeLibrary/Stdafx.h
@@ -1,3 +1,20 @@
+// OpenCppCoverage is an open source code coverage for C++.
+// Copyright (C) 2017 OpenCppCoverage
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
 // stdafx.h : include file for standard system include files,
 // or project specific include files that are used frequently,
 // but are changed infrequently

--- a/TestMixedModeLibrary/TestMixedModeLibrary.cpp
+++ b/TestMixedModeLibrary/TestMixedModeLibrary.cpp
@@ -1,0 +1,47 @@
+﻿// OpenCppCoverage is an open source code coverage for C++.
+// Copyright (C) 2017 OpenCppCoverage
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "stdafx.h"
+
+#pragma unmanaged
+int NativeCountVowels(wchar_t* pString)
+{
+	int count = 0;
+	const wchar_t* vowels = L"aeiouAEIOU";
+	while (*pString)
+	{
+		if (wcschr(vowels, *pString++))
+			count++;
+	}
+	return count;
+}
+#pragma managed
+using namespace System;
+
+namespace TestMixedModeLibrary
+{
+	public ref class Mixed
+	{
+	public: 
+		int CountVowels(String^ subject)
+		{
+			pin_ptr<Char> p =
+			const_cast<interior_ptr<Char>> (
+				PtrToStringChars(subject));
+			return NativeCountVowels(p);
+		};
+	};
+}

--- a/TestMixedModeLibrary/TestMixedModeLibrary.h
+++ b/TestMixedModeLibrary/TestMixedModeLibrary.h
@@ -1,0 +1,13 @@
+// MixedMode.h
+
+#pragma once
+
+using namespace System;
+
+namespace TestMixedModeLibrary {
+
+	public ref class Mixed
+	{
+		int CountVowels(String^ subject);
+	};
+}

--- a/TestMixedModeLibrary/TestMixedModeLibrary.h
+++ b/TestMixedModeLibrary/TestMixedModeLibrary.h
@@ -1,4 +1,20 @@
-// MixedMode.h
+// OpenCppCoverage is an open source code coverage for C++.
+// Copyright (C) 2017 OpenCppCoverage
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// TestMixedModeLibrary.h
 
 #pragma once
 

--- a/TestMixedModeLibrary/TestMixedModeLibrary.vcxproj
+++ b/TestMixedModeLibrary/TestMixedModeLibrary.vcxproj
@@ -1,0 +1,150 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D95BBB9A-66FF-44DB-B630-99C700CC31C9}</ProjectGuid>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <Keyword>ManagedCProj</Keyword>
+    <RootNamespace>MixedMode</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CLRSupport>true</CLRSupport>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CLRSupport>true</CLRSupport>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CLRSupport>true</CLRSupport>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CLRSupport>true</CLRSupport>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies />
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies />
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies />
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies />
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="TestMixedModeLibrary.h" />
+    <ClInclude Include="resource.h" />
+    <ClInclude Include="Stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="AssemblyInfo.cpp" />
+    <ClCompile Include="TestMixedModeLibrary.cpp" />
+    <ClCompile Include="Stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/TestMixedModeLibrary/TestMixedModeLibrary.vcxproj
+++ b/TestMixedModeLibrary/TestMixedModeLibrary.vcxproj
@@ -131,7 +131,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TestMixedModeLibrary.h" />
-    <ClInclude Include="resource.h" />
     <ClInclude Include="Stdafx.h" />
   </ItemGroup>
   <ItemGroup>

--- a/TestMixedModeLibrary/TestMixedModeLibrary.vcxproj.filters
+++ b/TestMixedModeLibrary/TestMixedModeLibrary.vcxproj.filters
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="TestMixedModeLibrary.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="AssemblyInfo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Stdafx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="TestMixedModeLibrary.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/TestMixedModeLibrary/TestMixedModeLibrary.vcxproj.filters
+++ b/TestMixedModeLibrary/TestMixedModeLibrary.vcxproj.filters
@@ -18,9 +18,6 @@
     <ClInclude Include="Stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="resource.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="TestMixedModeLibrary.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/TestMixedModeLibrary/resource.h
+++ b/TestMixedModeLibrary/resource.h
@@ -1,3 +1,0 @@
-//{{NO_DEPENDENCIES}}
-// Microsoft Visual C++ generated include file.
-// Used by app.rc

--- a/TestMixedModeLibrary/resource.h
+++ b/TestMixedModeLibrary/resource.h
@@ -1,0 +1,3 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by app.rc

--- a/Tools/PEFileHeader.cpp
+++ b/Tools/PEFileHeader.cpp
@@ -46,4 +46,13 @@ namespace Tools
 			THROW(L"PE file header machine is not supported: " +
 			      std::to_wstring(machine));
 	}
+
+        void IPEFileHeaderHandler::ReadFromProcessMemory(HANDLE hProcess,
+                                DWORD64 address,
+                                void* buffer,
+                                SIZE_T size)
+        {
+                return ::Tools::ReadProcessMemory(
+                                hProcess, address, buffer, size);
+        }
 }

--- a/Tools/PEFileHeader.hpp
+++ b/Tools/PEFileHeader.hpp
@@ -22,7 +22,7 @@
 
 namespace Tools
 {
-	class IPEFileHeaderHandler
+	class TOOLS_DLL IPEFileHeaderHandler
 	{
 	  public:
 		virtual ~IPEFileHeaderHandler() = default;
@@ -32,7 +32,12 @@ namespace Tools
 		virtual void OnNtHeader64(HANDLE hProcess,
 		                          DWORD64 baseOfImage,
 		                          const IMAGE_NT_HEADERS64&) = 0;
-	};
+          protected:
+               void ReadFromProcessMemory(HANDLE hProcess,
+                                          DWORD64 address,
+                                          void* buffer,
+                                          SIZE_T size);
+        };
 
 	class TOOLS_DLL PEFileHeader
 	{

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -1,0 +1,17 @@
+& .\x64\Debug\CppCoverageTest.exe --gtest_filter=-CodeCoverageRunnerTest.OptimizedBuild
+if ($LASTEXITCODE) {throw "CppCoverageTest failed"}
+
+& .\x64\Debug\ExporterTest.exe
+if ($LASTEXITCODE) {throw "ExporterTest failed"}
+
+& .\x64\Debug\FileFilterTest.exe --gtest_filter=-RelocationsExtractorTest.Extract
+if ($LASTEXITCODE) {throw "FileFilterTest failed"}
+
+& .\x64\Debug\OpenCppCoverageTest.exe
+if ($LASTEXITCODE) {throw "OpenCppCoverageTest failed"}
+
+& .\x64\Debug\PluginTest.exe
+if ($LASTEXITCODE) {throw "PluginTest failed"}
+
+& .\x64\Debug\ToolsTest.exe
+if ($LASTEXITCODE) {throw "ToolsTest failed"}


### PR DESCRIPTION
This is currently at proof of concept level, but fills the current coverage capabilities gap for C++/CLI : while OpenCover can report on the managed parts, there's nothing in the OSS world that I've seen that handles the native parts.  This should address the substance of issue #65 as well.

Substance of change

First, if the assembly has a CLR header, rather than dropping it then and there, read enough of that header to tell if it is IL-Only, and skip only if so.  This part works, but is less than elegant in its architecture.

Second, when enumerating lines, find the enclosing function symbol, and check whether it has a metadata token (indicating a managed method); if so, then skip that line.

At the moment, I have a couple of test projects I'm running it against manually; I still need to reverse-engineer the existing test sets to see how best to integrate the change there.