### PR TITLE
Add compatibility for the situation that '+++' may not come after '---'

### DIFF
--- a/CppCoverageTest/CodeCoverageRunnerTest.cpp
+++ b/CppCoverageTest/CodeCoverageRunnerTest.cpp
@@ -1,4 +1,4 @@
-// OpenCppCoverage is an open source code coverage for C++.
+Ôªø// OpenCppCoverage is an open source code coverage for C++.
 // Copyright (C) 2014 OpenCppCoverage
 //
 // This program is free software: you can redistribute it and/or modify
@@ -46,7 +46,7 @@
 #include "TestCoverageConsole/TestBasic.hpp"
 #include "TestCoverageConsole/TestThread.hpp"
 #include "TestCoverageConsole/SpecialLineInfo.hpp"
-#include "TestCoverageConsole/FileWithSpecialCharÈ‡Ë.hpp"
+#include "TestCoverageConsole/FileWithSpecialChar√©√†√®.hpp"
 #include "TestCoverageConsole/TestDiff.hpp"
 
 #include "TestCoverageSharedLib/TestCoverageSharedLib.hpp"

--- a/ExporterTest/CoverageDataSerializerTest.cpp
+++ b/ExporterTest/CoverageDataSerializerTest.cpp
@@ -1,4 +1,4 @@
-// OpenCppCoverage is an open source code coverage for C++.
+Ôªø// OpenCppCoverage is an open source code coverage for C++.
 // Copyright (C) 2014 OpenCppCoverage
 //
 // This program is free software: you can redistribute it and/or modify
@@ -57,7 +57,7 @@ namespace ExporterTest
 		//---------------------------------------------------------------------
 		Plugin::CoverageData CreateRandomCoverageData()
 		{
-			Plugin::CoverageData coverageData{ L"TestÈ", 42 };
+			Plugin::CoverageData coverageData{ L"Test√©", 42 };
 			std::default_random_engine generator;
 			std::uniform_int_distribution<int> distribution(0, 1);
 			
@@ -70,7 +70,7 @@ namespace ExporterTest
 				}
 			}
 
-			coverageData.AddModule("ÈË‡").AddFile("ÈË‡").AddLine(0, true);
+			coverageData.AddModule("√©√®√†").AddFile("√©√®√†").AddLine(0, true);
 
 			return coverageData;
 		}

--- a/FileFilter/UnifiedDiffParser.cpp
+++ b/FileFilter/UnifiedDiffParser.cpp
@@ -1,4 +1,4 @@
-// OpenCppCoverage is an open source code coverage for C++.
+﻿// OpenCppCoverage is an open source code coverage for C++.
 // Copyright (C) 2016 OpenCppCoverage
 //
 // This program is free software: you can redistribute it and/or modify
@@ -155,7 +155,14 @@ namespace FileFilter
 			else if (boost::algorithm::starts_with(line, FromFilePrefix))
 			{
 				sourceFileLines.push_back(line);
-				files.emplace_back(ExtractTargetFile(stream));
+				std::wstring nextLine;
+				if (stream.GetLine(nextLine))
+				{
+					if (boost::algorithm::starts_with(nextLine, ToFilePrefix))
+						files.emplace_back(ExtractTargetFile(nextLine));
+					else
+						sourceFileLines.push_back(nextLine);
+				}
 			}
 			else if (boost::algorithm::starts_with(line, L"@@"))
 				FillUpdatedLines(line, files, stream);
@@ -188,9 +195,14 @@ namespace FileFilter
 		if (!boost::algorithm::starts_with(line, ToFilePrefix))
 			ThrowError(stream, UnifiedDiffParserException::ErrorExpectFromFilePrefix);
 
+		return ExtractTargetFile(line);
+	}
+
+	std::filesystem::path UnifiedDiffParser::ExtractTargetFile(const std::wstring& line) const
+	{
 		const auto startIndex = ToFilePrefix.size();
 		const auto endIndex = line.find('\t');
-		
+
 		if (endIndex != std::string::npos)
 			return line.substr(startIndex, endIndex - startIndex);
 		return line.substr(startIndex);

--- a/FileFilter/UnifiedDiffParser.hpp
+++ b/FileFilter/UnifiedDiffParser.hpp
@@ -1,4 +1,4 @@
-// OpenCppCoverage is an open source code coverage for C++.
+﻿// OpenCppCoverage is an open source code coverage for C++.
 // Copyright (C) 2016 OpenCppCoverage
 
 // This program is free software: you can redistribute it and/or modify
@@ -43,6 +43,7 @@ namespace FileFilter
 		struct Stream;
 
 		std::filesystem::path ExtractTargetFile(Stream&) const;
+		std::filesystem::path ExtractTargetFile(const std::wstring& line) const;
 		HunksDifferences ExtractHunksDifferences(
 							const Stream&, 
 							const std::wstring& hunksDifferencesLine) const;

--- a/TestCoverageConsole/TestCoverageConsole.cpp
+++ b/TestCoverageConsole/TestCoverageConsole.cpp
@@ -1,4 +1,4 @@
-// OpenCppCoverage is an open source code coverage for C++.
+Ôªø// OpenCppCoverage is an open source code coverage for C++.
 // Copyright (C) 2014 OpenCppCoverage
 //
 // This program is free software: you can redistribute it and/or modify
@@ -27,7 +27,7 @@
 #include "TestCoverageConsole.hpp"
 #include "TestBasic.hpp"
 #include "TestThread.hpp"
-#include "FileWithSpecialCharÈ‡Ë.hpp"
+#include "FileWithSpecialChar√©√†√®.hpp"
 #include "TestDiff.hpp"
 
 namespace

--- a/ToolsTest/ToolTest.cpp
+++ b/ToolsTest/ToolTest.cpp
@@ -1,4 +1,4 @@
-// OpenCppCoverage is an open source code coverage for C++.
+Ôªø// OpenCppCoverage is an open source code coverage for C++.
 // Copyright (C) 2016 OpenCppCoverage
 //
 // This program is free software: you can redistribute it and/or modify
@@ -25,7 +25,7 @@ namespace ToolsTests
 		ASSERT_EQ("", Tools::ToLocalString(L""));
 		ASSERT_EQ("123456789", Tools::ToLocalString(L"123456789"));
 		ASSERT_EQ(1, Tools::ToLocalString(L"1").size());
-		ASSERT_EQ(std::string("È‡Ë"), Tools::ToLocalString(L"È‡Ë"));
+		ASSERT_EQ(std::string("√©√†√®"), Tools::ToLocalString(L"√©√†√®"));
 	}
 
 	//---------------------------------------------------------------------
@@ -34,12 +34,12 @@ namespace ToolsTests
 		ASSERT_EQ(L"", Tools::LocalToWString(""));
 		ASSERT_EQ(L"123456789", Tools::LocalToWString("123456789"));
 		ASSERT_EQ(1, Tools::LocalToWString("1").size());
-		ASSERT_EQ(std::wstring(L"È‡Ë"), Tools::LocalToWString("È‡Ë"));
+		ASSERT_EQ(std::wstring(L"√©√†√®"), Tools::LocalToWString("√©√†√®"));
 	}
 
 	//---------------------------------------------------------------------
 	TEST(Tool, Uft8)
 	{
-		ASSERT_EQ(L"È‡Ë", Tools::Utf8ToWString(Tools::ToUtf8String(L"È‡Ë")));
+		ASSERT_EQ(L"√©√†√®", Tools::Utf8ToWString(Tools::ToUtf8String(L"√©√†√®")));
 	}
 }


### PR DESCRIPTION
`UnifiedDiffParser::Parse` may throw an error unexpectedly when meeting a line starts with "---" but not follows by a line that doesn't start with "+++".  This may occur in the license file.