### PR TITLE
restrict argument quoting to those with whitespace

### DIFF
--- a/CppCoverage/Process.cpp
+++ b/CppCoverage/Process.cpp
@@ -41,9 +41,14 @@ namespace CppCoverage
 				std::vector<wchar_t> buffer;
 				for (const auto& argument : arguments)
 				{
-					buffer.push_back(L'\"');
+					const bool ws = (argument.find_first_of(L" \t\r\n\f\v") != std::string::npos);
+					if (ws) {
+						buffer.push_back(L'\"');
+					}
 					buffer.insert(buffer.end(), argument.begin(), argument.end());
-					buffer.push_back(L'\"');
+					if (ws) {
+						buffer.push_back(L'\"');
+					}
 					buffer.push_back(L' ');
 				}
 					


### PR DESCRIPTION
Don't wrap arguments in quotes unless necessary due to whitespace. This permits running picky applications that do not tolerate the extra quotes.

This is a duplicate of PR #176 (in case I messed that up)

For context, I was playing with using OpenCppCoverage with a DLL. I used ``7z.dll`` (7-zip) as an example and everything works fine when I run it via ``7z.exe``. But when I tried to run it via ``rundll32.exe`` it does not work - e.g.:

    OpenCppCoverage.exe  --modules 7z.dll --sources C:\Users\User\Desktop\7z2201-src  --export_type html:cov -- rundll32.exe 7z.dll SetLargePageMode
What happens is I get a pop-up error complaining:

    Error in 7z.dll
    Missing entry: "SetLargePageMode"
Note the quotes around the function name. I get that same error if I run ``rundll32`` directly like:

    rundll32.exe 7z.dll "SetLargePageMode"
But there is no pop-up/error if I run the same command without the quotes.